### PR TITLE
Bump Maven Bundle plugin version to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,8 +368,6 @@
         <mockito.version>2.4.2</mockito.version>
 
         <!--Maven plugins-->
-        <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
-        <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
         <!--<mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>-->
 
         <!--Character encoding for source files-->


### PR DESCRIPTION
Fixes issue #4.

This PR removes the `<maven.bundle.plugin.version>` variable from root `pom.xml` which overwrote the value (3.0.0) from WSO2 parent pom.