### PR TITLE
Add CarbonServerInfo OSGi reference to Msf4jHttpConnector class

### DIFF
--- a/components/core/pom.xml
+++ b/components/core/pom.xml
@@ -122,6 +122,7 @@
                     <instructions>
                         <Import-Package>
                             org.wso2.carbon.kernel.startupresolver.*; version="${carbon.kernel.version.range}",
+                            org.wso2.carbon.kernel.utils.*; version="${carbon.kernel.version.range}",
                             org.wso2.msf4j; version="${msf4j.version.range}",
                             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
                             io.netty.handler.*; version="${netty.version.range}",

--- a/components/core/pom.xml
+++ b/components/core/pom.xml
@@ -144,7 +144,7 @@
                             org.wso2.carbon.uis.spi.*;version="${project.version}"
                         </Export-Package>
                         <Carbon-Component>
-                            osgi.service;objectClass=org.wso2.carbon.uis.api.http.HttpConnector",
+                            osgi.service;objectClass="org.wso2.carbon.uis.api.http.HttpConnector",
                             osgi.service;objectClass="org.wso2.carbon.uis.spi.Server"
                         </Carbon-Component>
                         <Include-Resource>src/main/resources</Include-Resource>

--- a/components/core/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
+++ b/components/core/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.kernel.utils.CarbonServerInfo;
 import org.wso2.carbon.messaging.ServerConnector;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.listener.HTTPServerConnector;
@@ -84,6 +85,21 @@ public class Msf4jHttpConnector implements HttpConnector {
             LOGGER.debug("HTTP transport '{}' unregistered via '{}' from Microservices HTTP connector.",
                         httpTransport.getId(), serverConnector.getClass().getName());
         }
+    }
+
+    @Reference(
+            name = "carbon-server-info",
+            service = CarbonServerInfo.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCarbonServerInfo"
+    )
+    protected void setCarbonServerInfo(CarbonServerInfo carbonServerInfo) {
+        LOGGER.info("CarbonServerInfo instance '{}' registered.", carbonServerInfo.getClass().getName());
+    }
+
+    protected void unsetCarbonServerInfo(CarbonServerInfo carbonServerInfo) {
+        LOGGER.info("CarbonServerInfo instance '{}' unregistered.", carbonServerInfo.getClass().getName());
     }
 
     @Activate


### PR DESCRIPTION
As a workaround for "Server doesn't start-up after installing Dashboard features", this PR introduces necessary changes to delay microservices deployment until Carbon server fully starts.

Carbon server is considered as fully started when `org.wso2.carbon.kernel.utils.CarbonServerInfo` OSGi service is available.