### PR TITLE
Create web-ui-apps directory when installing org.wso2.carbon.uis.feature

### DIFF
--- a/features/org.wso2.carbon.uis.feature/src/main/resources/README.txt
+++ b/features/org.wso2.carbon.uis.feature/src/main/resources/README.txt
@@ -1,0 +1,1 @@
+This directory contains ReactJS based web apps that will be served by the Carbon UI Server.

--- a/features/org.wso2.carbon.uis.feature/src/main/resources/README.txt
+++ b/features/org.wso2.carbon.uis.feature/src/main/resources/README.txt
@@ -1,1 +1,0 @@
-This directory contains ReactJS based web apps that will be served by the Carbon UI Server.

--- a/features/org.wso2.carbon.uis.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.carbon.uis.feature/src/main/resources/p2.inf
@@ -1,0 +1,10 @@
+metaRequirements.0.namespace = org.eclipse.equinox.p2.iu
+metaRequirements.0.name = org.wso2.carbon.extensions.touchpoint
+metaRequirements.0.optional=true
+instructions.configure = \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/web-ui-apps/);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.uis_${feature.version}/README.txt,target:${installFolder}/../../deployment/web-ui-apps/README.txt,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/);\
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.uis_${feature.version}/README.txt,target:${installFolder}/../{runtime}/deployment/web-ui-apps/README.txt,overwrite:true);

--- a/features/org.wso2.carbon.uis.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.carbon.uis.feature/src/main/resources/p2.inf
@@ -4,7 +4,5 @@ metaRequirements.0.optional=true
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/web-ui-apps/);\
-org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.uis_${feature.version}/README.txt,target:${installFolder}/../../deployment/web-ui-apps/README.txt,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/);\
-org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/);\
-org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.uis_${feature.version}/README.txt,target:${installFolder}/../{runtime}/deployment/web-ui-apps/README.txt,overwrite:true);
+org.wso2.carbon.extensions.touchpoint.mkdir(path:${installFolder}/../{runtime}/deployment/web-ui-apps/);

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -435,7 +435,7 @@
                                 <delete dir="target/p2-repo" />
                                 <!-- TODO: Figure out a way to delete tmp.* files -->
                                 <delete file="target/tmp" />
-                                <delete dir="target/wso2carbon-kernel-${carbon.kernel.version}foo" />
+                                <delete dir="target/wso2carbon-kernel-${carbon.kernel.version}" />
                                 <delete dir="target/antrun" />
                                 <delete dir="target/director" />
                             </target>

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -314,7 +314,9 @@
                         </goals>
                         <configuration>
                             <repositoryURL>file:${basedir}/target/p2-repo</repositoryURL>
-                            <targetPath>file:${basedir}/target/WSO2Carbon/wso2</targetPath>
+                            <targetPath>
+                                file:${basedir}/target/wso2carbon-kernel-${carbon.kernel.version}/wso2
+                            </targetPath>
                             <runtime>default</runtime>
                         </configuration>
                     </execution>
@@ -327,7 +329,7 @@
                         <configuration>
                             <runtime>default</runtime>
                             <repositoryURL>file:${basedir}/target/p2-repo</repositoryURL>
-                            <destination>${basedir}/target/WSO2Carbon/wso2</destination>
+                            <destination>${basedir}/target/wso2carbon-kernel-${carbon.kernel.version}/wso2</destination>
                             <deleteOldRuntimeFiles>true</deleteOldRuntimeFiles>
                             <features>
                                 <!--Carbon UI Server features-->
@@ -413,7 +415,7 @@
                         <phase>package</phase>
                         <configuration>
                             <tasks>
-                                <replace dir="target/WSO2Carbon" token="false" value="true">
+                                <replace dir="target/wso2carbon-kernel-${carbon.kernel.version}" token="false" value="true">
                                     <include name="**/bundles.info" />
                                 </replace>
                             </tasks>
@@ -433,7 +435,7 @@
                                 <delete dir="target/p2-repo" />
                                 <!-- TODO: Figure out a way to delete tmp.* files -->
                                 <delete file="target/tmp" />
-                                <delete dir="target/WSO2Carbon" />
+                                <delete dir="target/wso2carbon-kernel-${carbon.kernel.version}foo" />
                                 <delete dir="target/antrun" />
                                 <delete dir="target/director" />
                             </target>

--- a/tests/distribution/src/assembly/bin.xml
+++ b/tests/distribution/src/assembly/bin.xml
@@ -28,7 +28,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>target/WSO2Carbon</directory>
+            <directory>target/wso2carbon-kernel-${carbon.kernel.version}</directory>
             <outputDirectory>.</outputDirectory>
             <fileMode>644</fileMode>
             <excludes>
@@ -43,7 +43,7 @@
         </fileSet>
 
         <fileSet>
-            <directory>target/WSO2Carbon</directory>
+            <directory>target/wso2carbon-kernel-${carbon.kernel.version}</directory>
             <outputDirectory>.</outputDirectory>
             <includes>
                 <include>**/*.sh</include>
@@ -54,7 +54,7 @@
 
         <fileSet>
             <directory>carbon-home</directory>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>.</outputDirectory>
             <excludes>
                 <exclude>**/*.ipr</exclude>
                 <exclude>**/*.iwr</exclude>


### PR DESCRIPTION
## Purpose
`org.wso2.carbon.uis.feature` feature does not create following directories upon installation.
- `<carbon_home>/deployment/web-ui-apps/`
- `<carbon_home>/wso2/<runtime>/deployment/web-ui-apps/`

Fixes #26 

## Goals
`org.wso2.carbon.uis.feature` feature should create said directories in the install phase.

## Approach
Create directories using `p2.inf`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
1.8.0_144