### PR TITLE
Make configuration.yaml file optional in a web app

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
@@ -61,7 +61,9 @@ public class AppCreator {
         Set<Theme> themes = appReference.getThemeReferences().stream()
                 .map(AppCreator::createTheme)
                 .collect(Collectors.toSet());
-        Configuration configuration = createConfiguration(appReference.getConfiguration());
+        Configuration configuration = appReference.getConfiguration()
+                .map(AppCreator::createConfiguration)
+                .orElse(new Configuration());
         I18nResources i18nResources = createI18nResources(appReference);
         return new App(appReference.getName(), appContext, pages, extensions, themes, i18nResources, configuration,
                        appReference.getPath());

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/reference/ArtifactAppReference.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/reference/ArtifactAppReference.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -132,14 +133,9 @@ public class ArtifactAppReference implements AppReference {
     }
 
     @Override
-    public FileReference getConfiguration() throws FileOperationException {
+    public Optional<FileReference> getConfiguration() throws FileOperationException {
         Path configuration = appDirectory.resolve(FILE_NAME_CONFIGURATION);
-        if (Files.exists(configuration)) {
-            return new ArtifactFileReference(configuration);
-        } else {
-            throw new FileOperationException("Cannot find app's configuration file '" + FILE_NAME_CONFIGURATION +
-                                             "' in app '" + appDirectory + "'.");
-        }
+        return Files.exists(configuration) ? Optional.of(new ArtifactFileReference(configuration)) : Optional.empty();
     }
 
     @Override

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/reference/AppReference.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/reference/AppReference.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.uis.internal.reference;
 
 import org.wso2.carbon.uis.internal.exception.FileOperationException;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -102,10 +103,9 @@ public interface AppReference {
     /**
      * Returns a reference to the configuration file of the app represented by this reference.
      *
-     * @return reference to the configuration file of this app
-     * @throws FileOperationException if cannot find or read configuration file
+     * @return if exists a reference to the configuration file of this app, otherwise {@link Optional#empty() empty}.
      */
-    FileReference getConfiguration() throws FileOperationException;
+    Optional<FileReference> getConfiguration() throws FileOperationException;
 
     /**
      * Returns the absolute path to the app represented by this reference.


### PR DESCRIPTION
## Purpose
Currently `configuration.yaml` file is mandatory in a web app.
Fixes #27 

## Goals
Make `configuration.yaml` optional.

## Approach
If `configuration.yaml` file doesn't exists, create an empty configuration object.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Test environment
JDK 1.8.0_144