### PR TITLE
Add Handlebars support

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -109,6 +109,15 @@
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <!-- Handlebars -->
+        <dependency>
+            <groupId>org.wso2.orbit.com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
 
         <!--Test-->
         <dependency>
@@ -149,7 +158,8 @@
             com.google.gson.*; version="${gson.version.range}",
             org.yaml.snakeyaml.*; version="${orbit.org.yaml.version.range}",
             org.apache.commons.lang3.*; version="${org.apache.commons.commons-lang3.version.range}",
-            org.apache.commons.io; version="${commons-io.wso2.version.range}"
+            org.apache.commons.io; version="${commons-io.wso2.version.range}",
+            com.github.jknack.handlebars.*;version="${orbit.com.github.jknack.handlebars.version.range}",
         </import.package>
         <private.package>org.wso2.carbon.uis.internal.*</private.package>
         <export.package>

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/App.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/App.java
@@ -162,7 +162,7 @@ public class App {
         String uriWithoutContextPath = request.getUriWithoutContextPath();
         Page matchingPage = getMatchingPage(uriWithoutContextPath);
         if (matchingPage != null) {
-            return matchingPage.getContent();
+            return matchingPage.render(request, configuration);
         }
 
         /* URL correction:

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Page.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Page.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.uis.api;
 
+import org.wso2.carbon.uis.api.exception.RenderingException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+
 import java.util.Objects;
 
 /**
@@ -25,20 +28,17 @@ import java.util.Objects;
  *
  * @since 0.8.0
  */
-public class Page implements Comparable<Page> {
+public abstract class Page implements Comparable<Page> {
 
     private final UriPatten uriPatten;
-    private final String content;
 
     /**
      * Creates a new page.
      *
      * @param uriPatten URI pattern of the page
-     * @param content   content of the page
      */
-    public Page(UriPatten uriPatten, String content) {
+    public Page(UriPatten uriPatten) {
         this.uriPatten = uriPatten;
-        this.content = content;
     }
 
     /**
@@ -51,15 +51,6 @@ public class Page implements Comparable<Page> {
     }
 
     /**
-     * Returns the content of this page.
-     *
-     * @return content of the page
-     */
-    public String getContent() {
-        return content;
-    }
-
-    /**
      * Checks whether this page matches to the given URI.
      *
      * @param uri URI to be matched
@@ -68,6 +59,17 @@ public class Page implements Comparable<Page> {
     public boolean matches(String uri) {
         return uriPatten.matches(uri);
     }
+
+    /**
+     * Renders this page and returns a HTML document.
+     *
+     *
+     * @param request
+     * @param configuration
+     * @return html
+     * @throws RenderingException if an error occurred during page rendering
+     */
+    public abstract String render(HttpRequest request, Configuration configuration) throws RenderingException;
 
     @Override
     public int compareTo(Page otherPage) {
@@ -81,11 +83,11 @@ public class Page implements Comparable<Page> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(uriPatten, content);
+        return Objects.hash(uriPatten);
     }
 
     @Override
     public String toString() {
-        return "Page{uriPatten=" + uriPatten + ", content='" + content + "'}";
+        return "Page{uriPatten=" + uriPatten + "}";
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/exception/RenderingException.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/exception/RenderingException.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.api.exception;
+
+/**
+ * Indicates an error occurred when rendering a page.
+ *
+ * @since 0.8.0
+ */
+public class RenderingException extends UISRuntimeException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public RenderingException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public RenderingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public RenderingException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public RenderingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/exception/RenderingException.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/exception/RenderingException.java
@@ -16,24 +16,6 @@
  * under the License.
  */
 
-/*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.wso2.carbon.uis.api.exception;
 
 /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/HbsPage.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/HbsPage.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.impl;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.HandlebarsException;
+import com.github.jknack.handlebars.Template;
+import org.wso2.carbon.uis.api.Configuration;
+import org.wso2.carbon.uis.api.Page;
+import org.wso2.carbon.uis.api.UriPatten;
+import org.wso2.carbon.uis.api.exception.RenderingException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+import org.wso2.carbon.uis.internal.exception.AppCreationException;
+import org.wso2.carbon.uis.internal.exception.FileOperationException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Page based on a Handlebars template.
+ *
+ * @since 0.10.3
+ */
+public class HbsPage extends Page {
+
+    private static final Handlebars HANDLEBARS = new Handlebars();
+
+    private final Template template;
+
+    /**
+     * Creates a new page based on a Handlebars template.
+     *
+     * @param uriPatten URI pattern of the page
+     * @param template  Handlebars template
+     */
+    public HbsPage(UriPatten uriPatten, String template) {
+        super(uriPatten);
+        this.template = compile(template);
+    }
+
+    @Override
+    public String render(HttpRequest request, Configuration configuration) throws RenderingException {
+        Map<String, String> model = Collections.singletonMap("@contextPath", request.getContextPath());
+        Context context = Context.newContext(model);
+        try {
+            return template.apply(context);
+        } catch (IOException e) {
+            throw new RenderingException("Cannot load page Handlebars template.", e);
+        } catch (HandlebarsException e) {
+            throw new RenderingException("Cannot render page Handlebars template.", e);
+        }
+    }
+
+    private static Template compile(String template) {
+        try {
+            return HANDLEBARS.compileInline(template);
+        } catch (IOException e) {
+            throw new FileOperationException("Cannot load Handlebars template.", e);
+        } catch (HandlebarsException e) {
+            throw new AppCreationException("Cannot compile Handlebars template.", e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/HtmlPage.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/HtmlPage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.impl;
+
+import org.wso2.carbon.uis.api.Configuration;
+import org.wso2.carbon.uis.api.Page;
+import org.wso2.carbon.uis.api.UriPatten;
+import org.wso2.carbon.uis.api.exception.RenderingException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+
+/**
+ * Page based on a HTML file.
+ *
+ * @since 0.10.3
+ */
+public class HtmlPage extends Page {
+
+    private final String content;
+
+    /**
+     * Creates a new page that renders given HTML content
+     *
+     * @param uriPatten URI pattern of the page
+     * @param content   HTML content of the page
+     */
+    public HtmlPage(UriPatten uriPatten, String content) {
+        super(uriPatten);
+        this.content = content;
+    }
+
+    @Override
+    public String render(HttpRequest request,
+                         Configuration configuration) throws RenderingException {
+        return content;
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/AppTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/AppTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.uis.api.http.HttpRequest;
 import org.wso2.carbon.uis.internal.exception.PageNotFoundException;
 import org.wso2.carbon.uis.internal.exception.PageRedirectException;
+import org.wso2.carbon.uis.internal.impl.HtmlPage;
 
 import java.util.Set;
 import java.util.SortedSet;
@@ -104,7 +105,7 @@ public class AppTest {
     }
 
     private static Page createPage(String uriPattern, String content) {
-        return new Page(new UriPatten(uriPattern), content);
+        return new HtmlPage(new UriPatten(uriPattern), content);
     }
 
     private static HttpRequest createRequest(String uriWithoutContextPath) {

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/PageTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/PageTest.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.uis.api;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.uis.api.exception.RenderingException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
 
 import static java.lang.Integer.signum;
 
@@ -112,6 +114,13 @@ public class PageTest {
     }
 
     private static Page createPage(String uriPattern) {
-        return new Page(new UriPatten(uriPattern), null);
+        return new Page(new UriPatten(uriPattern)) {
+
+            @Override
+            public String render(HttpRequest request,
+                                 Configuration configuration) throws RenderingException {
+                return null;
+            }
+        };
     }
 }

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -90,6 +90,14 @@
                                     <symbolicName>com.google.guava</symbolicName>
                                     <version>${guava.version}.0</version>
                                 </bundle>
+                                <bundle>
+                                    <symbolicName>handlebars</symbolicName>
+                                    <version>${orbit.com.github.jknack.handlebars.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.antlr.antlr4-runtime-osgi</symbolicName>
+                                    <version>${antlr-version}</version>
+                                </bundle>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,29 @@
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.wso2.version}</version>
             </dependency>
+            <!-- Handlebars -->
+            <dependency>
+                <groupId>org.wso2.orbit.com.github.jknack</groupId>
+                <artifactId>handlebars</artifactId>
+                <version>${orbit.com.github.jknack.handlebars.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.mozilla</groupId>
+                        <artifactId>rhino</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.abego.treelayout</groupId>
+                        <artifactId>org.abego.treelayout.core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!--Test-->
             <dependency>
@@ -413,6 +436,10 @@
         <org.apache.commons.commons-lang3.version.range>[3.1, 4.0)</org.apache.commons.commons-lang3.version.range>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
         <commons-io.wso2.version.range>[2.4.0, 3.0.0)</commons-io.wso2.version.range>
+        <!-- Handlebars -->
+        <orbit.com.github.jknack.handlebars.version>4.0.3.wso2v1</orbit.com.github.jknack.handlebars.version>
+        <orbit.com.github.jknack.handlebars.version.range>[4.0.3, 5.0.0)</orbit.com.github.jknack.handlebars.version.range>
+        <antlr-version>4.5.1-1</antlr-version>
 
         <!--Test-->
         <testng.version>6.9.10</testng.version>

--- a/tests/distribution/carbon-home/deployment/web-ui-apps/test/pages/index.hbs
+++ b/tests/distribution/carbon-home/deployment/web-ui-apps/test/pages/index.hbs
@@ -19,8 +19,15 @@
 <html>
 <head>
     <title>TEST</title>
+    <!--resources from app's public directory-->
+    <link href="{{@contextPath}}/public/app/css/styles.css" />
+    <script src="{{@contextPath}}/public/app/js/bundle.js"></script>
+    <!--resources from a theme-->
+    <link href="{{@contextPath}}/public/themes/dark/css/styles.css" />
+    <!--resources from an extension-->
+    <link href="{{@contextPath}}/public/extensions/widgets/line-chart/css/styles.css" />
 </head>
 <body>
-<h1>index.html served successfully!</h1>
+<h1>index.hbs served successfully!</h1>
 </body>
 </html>


### PR DESCRIPTION
## Purpose
As discussed in the "[Option for the customer to change the app context path in React based web apps](http://markmail.org/message/7ovuikaduq3wly2i)" architecture mail thread, Carbon UI Server needs support to render pages written with Handlebars.

## Goals
Support for render Handlebars pages (e.g.`index.hbs`). Following Handlebars context variables will be supported.
- `@contextPath`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
```hbs
    <!--resources from app's public directory-->
    <link href="{{@contextPath}}/public/app/css/styles.css" />
    <script src="{{@contextPath}}/public/app/js/bundle.js"></script>
    <!--resources from a theme-->
    <link href="{{@contextPath}}/public/themes/dark/css/styles.css" />
    <!--resources from an extension-->
    <link href="{{@contextPath}}/public/extensions/widgets/line-chart/css/styles.css" />
```

## Test environment
JDK 1.8.0_144