### PR TITLE
Fix bug of not unregistering web apps from transport when they are undeployed

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
@@ -126,7 +126,7 @@ public class Msf4jHttpConnector implements HttpConnector {
 
     @Override
     public void unregisterApp(String appName) {
-        Set<ServiceRegistration<Microservice>> registrations = microserviceRegistrations.get(appName);
+        Set<ServiceRegistration<Microservice>> registrations = microserviceRegistrations.removeAll(appName);
         if (registrations.isEmpty()) {
             throw new IllegalArgumentException("Cannot unregister web app '" + appName +
                                                "'. App might be already unregistered or not be registered at all.");


### PR DESCRIPTION
## Purpose
Once a web app get registered to the transport, it does not get unregistered when it is undeployed.
Fixes #35 

## Goals
Web app should get unregistered from the transport when it is undeployed.

## Approach
Instead of `SetMultimap.get(key)` use `SetMultimap.removeAll(key)` in `Msf4jHttpConnector.unregisterApp(appName)` method.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
