### PR TITLE
Bump dependency versions to newer

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.10.7-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.10.7-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -389,8 +389,8 @@
         <carbon.deployment.version.range>[5.0.0, 6.0.0)</carbon.deployment.version.range>
 
         <!--Config-->
-        <carbon.config.version>2.0.3</carbon.config.version>
-        <carbon.config.version.range>[2.0.0, 3.0.0)</carbon.config.version.range>
+        <carbon.config.version>2.1.2</carbon.config.version>
+        <carbon.config.version.range>[2.1.2, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.8</carbon.securevault.version>
         <carbon.utils.version>2.0.2</carbon.utils.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.wso2.carbon.uis</groupId>
     <artifactId>uis-parent</artifactId>
-    <version>0.10.7-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WSO2 Carbon UI Server - Parent</name>
@@ -377,7 +377,7 @@
     </build>
 
     <properties>
-        <carbon.uis.version>0.10.7-SNAPSHOT</carbon.uis.version>
+        <carbon.uis.version>0.11.0-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
         <carbon.kernel.version>5.2.0</carbon.kernel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
 
         <!--Deployment-->
-        <carbon.deployment.version>5.1.3</carbon.deployment.version>
+        <carbon.deployment.version>5.1.5</carbon.deployment.version>
         <carbon.deployment.version.range>[5.0.0, 6.0.0)</carbon.deployment.version.range>
 
         <!--Config-->
@@ -395,18 +395,18 @@
         <carbon.utils.version>2.0.2</carbon.utils.version>
 
         <!--MSF4J-->
-        <msf4j.version>2.4.0-m1</msf4j.version>
-        <msf4j.version.range>[2.0.0, 3.0.0)</msf4j.version.range>
+        <msf4j.version>2.4.2</msf4j.version>
+        <msf4j.version.range>[2.4.2, 3.0.0)</msf4j.version.range>
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>
         <!--Transport-->
-        <carbon.messaging.version>3.0.0</carbon.messaging.version>
-        <carbon.messaging.version.range>[3.0.0, 4.0.0)</carbon.messaging.version.range>
-        <carbon.transport.version>5.0.0-m1</carbon.transport.version>
-        <carbon.transport.version.range>[5.0.0,6.0.0)</carbon.transport.version.range>
+        <carbon.messaging.version>3.0.1</carbon.messaging.version>
+        <carbon.messaging.version.range>[3.0.1, 4.0.0)</carbon.messaging.version.range>
+        <carbon.transport.version>5.0.1</carbon.transport.version>
+        <carbon.transport.version.range>[5.0.1, 6.0.0)</carbon.transport.version.range>
         <!--Metrics-->
-        <carbon.metrics.version>2.3.0</carbon.metrics.version>
-        <carbon.jndi.version>1.0.3</carbon.jndi.version>
-        <carbon.datasources.version>1.1.2</carbon.datasources.version>
+        <carbon.metrics.version>2.3.2</carbon.metrics.version>
+        <carbon.jndi.version>1.0.4</carbon.jndi.version>
+        <carbon.datasources.version>1.1.3</carbon.datasources.version>
 
         <!--OSGi-->
         <org.osgi.api.version>6.0.0</org.osgi.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -380,8 +380,8 @@
         <carbon.uis.version>0.10.7-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
-        <carbon.kernel.version>5.2.0-alpha</carbon.kernel.version>
-        <carbon.kernel.version.range>[5.0.0, 6.0.0)</carbon.kernel.version.range>
+        <carbon.kernel.version>5.2.0</carbon.kernel.version>
+        <carbon.kernel.version.range>[5.2.0, 6.0.0)</carbon.kernel.version.range>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
 
         <!--Deployment-->

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>0.10.7-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.10.7-SNAPSHOT</version>
+        <version>0.11.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
Need to migrate to Carbon Kernel v5.2.0. Also need to migrate to MSF4J v2.4.2 for necessary bug fixes.

## Approach
Following dependencies will be bumped to respective versions.
- MSF4J v2.4.2
- carbon-messaging v3.0.1
- carbon-transport v5.0.1
- carbon-metrics v2.3.2
- carbon-jndi v1.0.4
- carbon-datasources v1.1.3
- carbon-deployment v5.1.5
- carbon-config to v2.1.2
- carbon-kernel to v5.2.0

Also bumps the repo version to 0.11.0-SNAPSHOT

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
