### PR TITLE
Load configuration.yaml file in a web app

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -156,7 +156,7 @@
             io.netty.handler.*; version="${netty.version.range}",
             com.google.common.*; version="${guava.version.range}",
             com.google.gson.*; version="${gson.version.range}",
-            org.yaml.snakeyaml.*; version="${orbit.org.yaml.version.range}",
+            org.yaml.snakeyaml.*; version="${snakeyaml.version.range}",
             org.apache.commons.lang3.*; version="${org.apache.commons.commons-lang3.version.range}",
             org.apache.commons.io; version="${commons-io.wso2.version.range}",
             com.github.jknack.handlebars.*;version="${orbit.com.github.jknack.handlebars.version.range}",

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
@@ -18,9 +18,8 @@
 
 package org.wso2.carbon.uis.api;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_CACHE_CONTROL;
@@ -95,19 +94,20 @@ public class Configuration {
          * @param staticResources HTTP response headers for static resources
          */
         public HttpResponseHeaders(Map<String, String> pages, Map<String, String> staticResources) {
-            this.pages = ImmutableMap.<String, String>builder()
-                    .put(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff")
-                    .put(HEADER_X_XSS_PROTECTION, "1; mode=block")
-                    .put(HEADER_CACHE_CONTROL, "no-store, no-cache, must-revalidate, private")
-                    .put(HEADER_EXPIRES, "0")
-                    .put(HEADER_PRAGMA, "no-cache")
-                    .put(HEADER_X_FRAME_OPTIONS, "DENY")
-                    .putAll(pages)
-                    .build();
-            this.staticResources = ImmutableMap.<String, String>builder()
-                    .put(HEADER_CACHE_CONTROL, "public,max-age=2592000")
-                    .putAll(staticResources)
-                    .build();
+            Map<String, String> pagesHttpHeaders = new HashMap<>();
+            pagesHttpHeaders.put(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
+            pagesHttpHeaders.put(HEADER_X_XSS_PROTECTION, "1; mode=block");
+            pagesHttpHeaders.put(HEADER_CACHE_CONTROL, "no-store, no-cache, must-revalidate, private");
+            pagesHttpHeaders.put(HEADER_EXPIRES, "0");
+            pagesHttpHeaders.put(HEADER_PRAGMA, "no-cache");
+            pagesHttpHeaders.put(HEADER_X_FRAME_OPTIONS, "DENY");
+            pagesHttpHeaders.putAll(pages);
+            this.pages = Collections.unmodifiableMap(pagesHttpHeaders);
+
+            Map<String, String> staticResourcesHttpHeaders = new HashMap<>();
+            staticResourcesHttpHeaders.put(HEADER_CACHE_CONTROL, "public,max-age=2592000");
+            staticResourcesHttpHeaders.putAll(staticResources);
+            this.staticResources = Collections.unmodifiableMap(staticResourcesHttpHeaders);
         }
 
         /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
@@ -29,13 +29,7 @@ import org.wso2.carbon.uis.internal.exception.PageRedirectException;
 import org.wso2.carbon.uis.internal.io.StaticResolver;
 
 import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_HTML;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_CACHE_CONTROL;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_EXPIRES;
 import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_LOCATION;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_PRAGMA;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_CONTENT_TYPE_OPTIONS;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_FRAME_OPTIONS;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_XSS_PROTECTION;
 import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_BAD_REQUEST;
 import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_FOUND;
 import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
@@ -70,7 +64,7 @@ public class RequestDispatcher {
     /**
      * Serves the specified HTTP request.
      *
-     * @param request     HTTP request to be served
+     * @param request HTTP request to be served
      * @return HTTP response
      */
     public HttpResponse serve(HttpRequest request) {
@@ -142,11 +136,6 @@ public class RequestDispatcher {
     }
 
     private void setResponseSecurityHeaders(App app, HttpResponse httpResponse) {
-        httpResponse.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
-        httpResponse.setHeader(HEADER_X_XSS_PROTECTION, "1; mode=block");
-        httpResponse.setHeader(HEADER_CACHE_CONTROL, "no-store, no-cache, must-revalidate, private");
-        httpResponse.setHeader(HEADER_EXPIRES, "0");
-        httpResponse.setHeader(HEADER_PRAGMA, "no-cache");
-        httpResponse.setHeader(HEADER_X_FRAME_OPTIONS, "DENY");
+        app.getConfiguration().getResponseHeaders().forPages().forEach(httpResponse::setHeader);
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.uis.api.Theme;
 import org.wso2.carbon.uis.api.UriPatten;
 import org.wso2.carbon.uis.api.exception.RenderingException;
 import org.wso2.carbon.uis.api.http.HttpRequest;
+import org.wso2.carbon.uis.internal.deployment.parser.YamlFileParser;
 import org.wso2.carbon.uis.internal.exception.AppCreationException;
 import org.wso2.carbon.uis.internal.impl.HbsPage;
 import org.wso2.carbon.uis.internal.impl.HtmlPage;
@@ -121,6 +122,7 @@ public class AppCreator {
     }
 
     private static Configuration createConfiguration(FileReference fileReference) {
-        return Configuration.defaultConfiguration();
+        ConfigurationYaml configurationYaml = YamlFileParser.parse(fileReference, ConfigurationYaml.class);
+        return configurationYaml.toConfiguration();
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
@@ -71,7 +71,7 @@ public class AppCreator {
                 .collect(Collectors.toSet());
         Configuration configuration = appReference.getConfiguration()
                 .map(AppCreator::createConfiguration)
-                .orElse(new Configuration());
+                .orElse(Configuration.defaultConfiguration());
         return new App(appReference.getName(), appContext, pages, extensions, themes, i18nResources, configuration,
                        appReference.getPath());
     }
@@ -121,6 +121,6 @@ public class AppCreator {
     }
 
     private static Configuration createConfiguration(FileReference fileReference) {
-        return new Configuration();
+        return Configuration.defaultConfiguration();
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/ConfigurationYaml.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/ConfigurationYaml.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.deployment;
+
+import org.wso2.carbon.uis.api.Configuration;
+
+import java.util.Map;
+
+/**
+ * Bean class that represents the {@code configuration.yaml} file of a web app.
+ *
+ * @since 0.12.1
+ */
+public class ConfigurationYaml {
+
+    private boolean httpsOnly;
+    private ResponseHeaders responseHeaders;
+
+    /**
+     * Returns {@code httpsOnly} config value.
+     *
+     * @return {@code httpsOnly} config
+     */
+    public boolean isHttpsOnly() {
+        return httpsOnly;
+    }
+
+    /**
+     * Sets {@code httpsOnly} config value.
+     *
+     * @param httpsOnly config value
+     */
+    public void setHttpsOnly(boolean httpsOnly) {
+        this.httpsOnly = httpsOnly;
+    }
+
+    /**
+     * Returns {@code responseHeaders} config value.
+     *
+     * @return {@code responseHeaders} config.
+     */
+    public ResponseHeaders getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    /**
+     * Sets {@code responseHeaders} config value.
+     *
+     * @param responseHeaders config value
+     */
+    public void setResponseHeaders(ResponseHeaders responseHeaders) {
+        this.responseHeaders = responseHeaders;
+    }
+
+    /**
+     * Returns this YAML configuration as a {@link Configuration} object.
+     *
+     * @return {@link Configuration} object
+     */
+    public Configuration toConfiguration() {
+        return new Configuration(this.httpsOnly,
+                                 new Configuration.HttpResponseHeaders(this.responseHeaders.getPages(),
+                                                                       this.responseHeaders.getResources()));
+    }
+
+    /**
+     * Bean class for {@code responseHeaders} config.
+     *
+     * @since 0.12.1
+     */
+    public static class ResponseHeaders {
+
+        private Map<String, String> pages;
+        private Map<String, String> resources;
+
+        /**
+         * Returns {@code pages} config value.
+         *
+         * @return {@code pages} config value.
+         */
+        public Map<String, String> getPages() {
+            return pages;
+        }
+
+        /**
+         * Sets {@code pages} config value.
+         *
+         * @param pages config value.
+         */
+        public void setPages(Map<String, String> pages) {
+            this.pages = pages;
+        }
+
+        /**
+         * Returns {@code resources} config value.
+         *
+         * @return {@code resources} config value
+         */
+        public Map<String, String> getResources() {
+            return resources;
+        }
+
+        /**
+         * Sets {@code resources} config value.
+         *
+         * @param resources config value
+         */
+        public void setResources(Map<String, String> resources) {
+            this.resources = resources;
+        }
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/parser/YamlFileParser.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/parser/YamlFileParser.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.deployment.parser;
+
+import org.wso2.carbon.uis.internal.exception.ConfigurationException;
+import org.wso2.carbon.uis.internal.exception.FileOperationException;
+import org.wso2.carbon.uis.internal.reference.FileReference;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Parser for YAML configuration files in web apps.
+ *
+ * @since 0.12.1
+ */
+public class YamlFileParser {
+
+    /**
+     * Parses the given YAML configuration file and de-serialize the content into given bean type.
+     *
+     * @param yamlFile reference to the YAML configuration file
+     * @param type     class of the bean to be used when de-serializing
+     * @param <T>      type of the bean class to be used when de-serializing
+     * @return returns the populated bean instance
+     * @throws ConfigurationException if cannot read or parse the content of the specified YAML file
+     */
+    public static <T> T parse(FileReference yamlFile, Class<T> type) throws ConfigurationException {
+        T loadedBean;
+        try {
+            loadedBean = new Yaml(new ClassLoaderConstructor(type)).loadAs(yamlFile.getContent(), type);
+        } catch (FileOperationException e) {
+            throw new ConfigurationException(
+                    "Cannot read the YAML configuration file '" + yamlFile.getFilePath() + "'.", e);
+        } catch (Exception e) {
+            throw new ConfigurationException(
+                    "Cannot parse the YAML configuration file '" + yamlFile.getFilePath() + "'.", e);
+        }
+        if (loadedBean == null) {
+            // Either configuration file is empty or has only comments.
+            throw new ConfigurationException(
+                    "Cannot load the YAML configuration file '" + yamlFile.getFilePath() + "' as it is empty.");
+        }
+        return loadedBean;
+    }
+
+    /**
+     * OSGi friendly YAML constructor that loads classes through a given class object.
+     *
+     * @since 0.12.1
+     */
+    private static class ClassLoaderConstructor extends Constructor {
+
+        private final ClassLoader classLoader;
+
+        /**
+         * Creates a new constructor.
+         *
+         * @param aClass class that uses for class loading
+         */
+        public ClassLoaderConstructor(Class aClass) {
+            super(Object.class);
+            this.classLoader = aClass.getClassLoader();
+        }
+
+        @Override
+        protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+            return Class.forName(name, true, classLoader);
+        }
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/ConfigurationException.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/ConfigurationException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.exception;
+
+/**
+ * Indicates an error happens when reading or parsing or loading or processing configuration.
+ *
+ * @since 0.12.1
+ */
+public class ConfigurationException extends AppCreationException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public ConfigurationException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public ConfigurationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/StaticResolver.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/StaticResolver.java
@@ -326,7 +326,7 @@ public class StaticResolver {
     }
 
     private void setResponseSecurityHeaders(App app, HttpResponse response) {
-        app.getConfiguration().getResponseHeaders().getStaticResources().forEach(response::setHeader);
+        app.getConfiguration().getResponseHeaders().forStaticResources().forEach(response::setHeader);
     }
 
     private void setCacheHeaders(ZonedDateTime lastModifiedDate, HttpResponse response) {

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -76,7 +76,7 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.yaml.snakeyaml</symbolicName>
-                                    <version>${org.snakeyaml.version}</version>
+                                    <version>${snakeyaml.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.apache.commons.lang3</symbolicName>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>${org.snakeyaml.version}</version>
+                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -430,8 +430,8 @@
         <guava.version.range>[18.0,19.0)</guava.version.range>
         <gson.version>2.6.2</gson.version>
         <gson.version.range>[2.6.2,3)</gson.version.range>
-        <org.snakeyaml.version>1.17</org.snakeyaml.version>
-        <orbit.org.yaml.version.range>[1.17.0,2.0.0)</orbit.org.yaml.version.range>
+        <snakeyaml.version>1.19</snakeyaml.version>
+        <snakeyaml.version.range>[1.19.0, 2.0.0)</snakeyaml.version.range>
         <org.apache.commons.commons-lang3.version>3.1</org.apache.commons.commons-lang3.version>
         <org.apache.commons.commons-lang3.version.range>[3.1, 4.0)</org.apache.commons.commons-lang3.version.range>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>

--- a/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
+++ b/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
@@ -1,0 +1,9 @@
+# Set this to true if you want to deploy this web app in HTTPS
+httpsOnly: true
+
+#
+responseHeaders:
+  resources:
+    "Content-Security-Policy": "default-src 'none'; script-src 'self' ssl.google-analytics.com;"
+  pages:
+    "X-Frame-Options": "DENY"

--- a/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
+++ b/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
@@ -1,9 +1,11 @@
-# Set this to true if you want to deploy this web app in HTTPS
+# Set this to true if you want to deploy this web app *only* in HTTPS.
 httpsOnly: true
 
-#
+# HTTP response headers.
 responseHeaders:
+  # HTTP response headers for static resources.
   resources:
     "Content-Security-Policy": "default-src 'none'; script-src 'self' ssl.google-analytics.com;"
+  # HTTP response headers for pages.
   pages:
     "X-Frame-Options": "DENY"


### PR DESCRIPTION
## Purpose
Currently `configuration.yaml` file of a web app is not loaded (see [`AppCreator.createConfiguration(FileReference fileReference)`](https://github.com/wso2/carbon-ui-server/blob/v0.12.0/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java#L124))

## Goals
If exists, load & consume `configuration.yaml` file of a web app.

## Approach
- Added `ConfigurationYaml` class that acts as the bean class for `configuration.yaml` file.
- Refactored `Configuration` class.

## Documentation
`configuration.yaml`
```yaml
# Set this to true if you want to deploy this web app *only* in HTTPS.
httpsOnly: true

# HTTP response headers.
responseHeaders:
  # HTTP response headers for static resources.
  resources:
    "Content-Security-Policy": "default-src 'none'; script-src 'self' ssl.google-analytics.com;"
  # HTTP response headers for pages.
  pages:
    "X-Frame-Options": "DENY"
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
See [`tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml`](https://github.com/wso2/carbon-ui-server/blob/d002edf83c02a5632546c06b64a8ab910007488f/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml)