### PR TITLE
Enable `httpsOnly` configuration in the `configuration.yaml` of a web app

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
@@ -29,6 +29,8 @@ import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_CONTENT_TYPE_OP
 import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_FRAME_OPTIONS;
 import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_XSS_PROTECTION;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * Represents a configurations for a web App.
  *
@@ -36,8 +38,17 @@ import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_X_XSS_PROTECTION;
  */
 public class Configuration {
 
+    /**
+     * Default configuration for an app.
+     */
+    public static final Configuration DEFAULT_CONFIGURATION;
+
     private final boolean httpsOnly;
     private final HttpResponseHeaders responseHeaders;
+
+    static {
+        DEFAULT_CONFIGURATION = new Configuration(false, new HttpResponseHeaders(emptyMap(), emptyMap()));
+    }
 
     /**
      * Creates a new configuration.
@@ -66,15 +77,6 @@ public class Configuration {
      */
     public HttpResponseHeaders getResponseHeaders() {
         return responseHeaders;
-    }
-
-    /**
-     * Returns a default configuration for an app.
-     *
-     * @return a default configuration
-     */
-    public static Configuration defaultConfiguration() {
-        return new Configuration(false, new HttpResponseHeaders(Collections.emptyMap(), Collections.emptyMap()));
     }
 
     /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/http/HttpConnector.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/http/HttpConnector.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.uis.api.http;
 
+import org.wso2.carbon.uis.api.App;
+
 import java.util.function.Function;
 
 /**
@@ -30,11 +32,10 @@ public interface HttpConnector {
     /**
      * Registers a web app to the transport.
      *
-     * @param appName        name of the app
-     * @param appContextPath context path of the app
-     * @param httpListener   HTTP requests listener that handles the incoming HTTP requests for the registering app
+     * @param app          app to be registered
+     * @param httpListener HTTP requests listener that handles the incoming HTTP requests for the registering app
      */
-    void registerApp(String appName, String appContextPath, Function<HttpRequest, HttpResponse> httpListener);
+    void registerApp(App app, Function<HttpRequest, HttpResponse> httpListener);
 
     /**
      * Unregisters the specified app from the transport.

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/CarbonUiServer.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/CarbonUiServer.java
@@ -96,7 +96,7 @@ public class CarbonUiServer implements Server, AppDeploymentEventListener {
     public void appDeploymentEvent(App app) {
         deployedApps.put(app.getName(), app);
         RequestDispatcher requestDispatcher = new RequestDispatcher(app);
-        httpConnector.registerApp(app.getName(), app.getContextPath(), requestDispatcher::serve);
+        httpConnector.registerApp(app, requestDispatcher::serve);
     }
 
     @Override

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppCreator.java
@@ -72,7 +72,7 @@ public class AppCreator {
                 .collect(Collectors.toSet());
         Configuration configuration = appReference.getConfiguration()
                 .map(AppCreator::createConfiguration)
-                .orElse(Configuration.defaultConfiguration());
+                .orElse(Configuration.DEFAULT_CONFIGURATION);
         return new App(appReference.getName(), appContext, pages, extensions, themes, i18nResources, configuration,
                        appReference.getPath());
     }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.ServerConnector;
 import org.wso2.carbon.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.listener.HTTPServerConnector;
+import org.wso2.carbon.uis.api.App;
 import org.wso2.carbon.uis.api.http.HttpConnector;
 import org.wso2.carbon.uis.api.http.HttpRequest;
 import org.wso2.carbon.uis.api.http.HttpResponse;
@@ -111,16 +112,17 @@ public class Msf4jHttpConnector implements HttpConnector {
     }
 
     @Override
-    public void registerApp(String appName, String appContextPath, Function<HttpRequest, HttpResponse> httpListener) {
+    public void registerApp(App app, Function<HttpRequest, HttpResponse> httpListener) {
         for (HttpTransport httpTransport : httpTransports) {
             Dictionary<String, String> dictionary = new Hashtable<>();
             dictionary.put("CHANNEL_ID", httpTransport.getId());
-            dictionary.put("contextPath", appContextPath);
+            dictionary.put("contextPath", app.getContextPath());
             ServiceRegistration<Microservice> microserviceServiceRegistration =
                     bundleContext.registerService(Microservice.class, new WebappMicroservice(httpListener), dictionary);
 
-            microserviceRegistrations.put(appName, microserviceServiceRegistration);
-            LOGGER.info("Web app '{}' is available at '{}'.", appName, httpTransport.getAppUrl(appContextPath));
+            microserviceRegistrations.put(app.getName(), microserviceServiceRegistration);
+            LOGGER.info("Web app '{}' is available at '{}'.", app.getName(),
+                        httpTransport.getAppUrl(app.getContextPath()));
         }
     }
 
@@ -202,7 +204,7 @@ public class Msf4jHttpConnector implements HttpConnector {
          * @return {@code true} if the {@link #getScheme() scheme} is HTTPS, otherwise {@code false}
          */
         public boolean isSecured() {
-            return host.equalsIgnoreCase("https");
+            return scheme.equalsIgnoreCase("https");
         }
 
         /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/OverriddenApp.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/impl/OverriddenApp.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.uis.internal.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.api.Configuration;
 import org.wso2.carbon.uis.api.Extension;
 import org.wso2.carbon.uis.api.I18nResource;
 import org.wso2.carbon.uis.api.Page;
@@ -29,6 +30,7 @@ import org.wso2.carbon.uis.api.Theme;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -55,7 +57,7 @@ public class OverriddenApp extends App {
     public OverriddenApp(App base, App override) {
         super(override.getName(), override.getContextPath(),
               getPagesFrom(base, override), getExtensionsFrom(base, override), getThemesFrom(base, override),
-              getI18nResourcesFrom(base, override), override.getConfiguration(), getPathsFrom(base, override));
+              getI18nResourcesFrom(base, override), getConfigurationFrom(base, override), getPathsFrom(base, override));
         this.base = base;
         this.override = override;
     }
@@ -100,6 +102,12 @@ public class OverriddenApp extends App {
                 .addAll(getI18nResourcesOf(override))
                 .addAll(getI18nResourcesOf(base))
                 .build();
+    }
+
+    private static Configuration getConfigurationFrom(App base, App override) {
+        return Objects.equals(override.getConfiguration(), Configuration.DEFAULT_CONFIGURATION) ?
+                base.getConfiguration() :
+                override.getConfiguration();
     }
 
     private static List<String> getPathsFrom(App base, App override) {


### PR DESCRIPTION
## Purpose
Currently `httpsOnly` configuration value in the `configuration.yaml` file of a web app, is not honored when registering web apps to transport layer.
Fixes #33 

## Goals
If `httpsOnly` is `true` then that web app should be only be deployed to HTTPS transports. If `false` then register to all HTTP transports.

## Approach
Change parameters of `registerApp` method of `HttpConnector` interface to accept registering  `App` object.
```java
void registerApp(App app, Function<HttpRequest, HttpResponse> httpListener);
```
In `Msf4jHttpConnector.registerApp` method, get app's configuration and check for the `httpsOnly` configuration (`app.getConfiguration().isHttpsOnly()`). If that is `true` then register only for HTTPS transports.

## Documentation
`configuration.yaml`
```yaml
# Set this to true if you want to deploy this web app *only* in HTTPS.
httpsOnly: true
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
See [`tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml`](https://github.com/wso2/carbon-ui-server/blob/v0.12.1/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml)

## Related PRs
 #41
