### PR TITLE
Override context path of a web app via the deployment.yaml

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
 
         <!--Config-->
+        <dependency>
+            <groupId>org.wso2.carbon.config</groupId>
+            <artifactId>org.wso2.carbon.config</artifactId>
+        </dependency>
 
         <!--MSF4J-->
         <dependency>
@@ -144,7 +148,8 @@
     <properties>
         <import.package>
             org.wso2.carbon.kernel.startupresolver.*; version="${carbon.kernel.version.range}",
-            org.wso2.carbon.deployment.engine.*;version="${carbon.deployment.version.range}",
+            org.wso2.carbon.deployment.engine.*; version="${carbon.deployment.version.range}",
+            org.wso2.carbon.config.*; version="${carbon.config.version.range}",
             org.wso2.msf4j; version="${msf4j.version.range}",
             javax.ws.rs.*; version="${javax.ws.rs.version.range}",
             org.wso2.carbon.messaging; version="${carbon.messaging.version.range}",
@@ -167,6 +172,9 @@
             org.wso2.carbon.uis.api.*;version="${project.version}",
             org.wso2.carbon.uis.spi.*;version="${project.version}"
         </export.package>
+        <carbon.component>
+            osgi.service; objectClass="org.wso2.carbon.deployment.engine.Deployer"
+        </carbon.component>
     </properties>
 
 </project>

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.api;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Bean class for server configurations.
+ *
+ * @since 0.12.6
+ */
+@Configuration(namespace = "wso2.carbon-ui-server", description = "Configurations for Carbon UI Server")
+public class ServerConfiguration {
+
+    @Element(description = "context paths for web apps")
+    private Map<String, String> contextPaths = Collections.emptyMap();
+
+    /**
+     * Returns overrding context paths for web apps.
+     *
+     * @return overriding context paths
+     */
+    public Map<String, String> getContextPaths() {
+        return contextPaths;
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/CarbonUiServer.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/CarbonUiServer.java
@@ -41,13 +41,8 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @since 0.8.0
  */
-@Component(name = "org.wso2.carbon.uis.internal.CarbonUiServer",
-           service = {Server.class, AppDeploymentEventListener.class},
-           immediate = true,
-           property = {
-                   "componentName=wso2-carbon-ui-server"
-           }
-)
+@Component(service = {Server.class, AppDeploymentEventListener.class},
+           immediate = true)
 public class CarbonUiServer implements Server, AppDeploymentEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CarbonUiServer.class);
@@ -58,8 +53,7 @@ public class CarbonUiServer implements Server, AppDeploymentEventListener {
      */
     private final ConcurrentMap<String, App> deployedApps = new ConcurrentHashMap<>();
 
-    @Reference(name = "httpConnector",
-               service = HttpConnector.class,
+    @Reference(service = HttpConnector.class,
                cardinality = ReferenceCardinality.MANDATORY,
                policy = ReferencePolicy.DYNAMIC,
                unbind = "unsetHttpConnector")

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/Msf4jHttpConnector.java
@@ -57,11 +57,8 @@ import java.util.function.Function;
  *
  * @since 0.8.0
  */
-@Component(name = "org.wso2.carbon.uis.internal.http.Msf4jHttpConnector",
-           service = HttpConnector.class,
-           immediate = true
-)
-@SuppressWarnings("unused")
+@Component(service = HttpConnector.class,
+           immediate = true)
 public class Msf4jHttpConnector implements HttpConnector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Msf4jHttpConnector.class);
@@ -78,13 +75,10 @@ public class Msf4jHttpConnector implements HttpConnector {
         this.microserviceRegistrations = HashMultimap.create();
     }
 
-    @Reference(
-            name = "http-connector-provider",
-            service = ServerConnector.class,
-            cardinality = ReferenceCardinality.AT_LEAST_ONE,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetCarbonTransport"
-    )
+    @Reference(service = ServerConnector.class,
+               cardinality = ReferenceCardinality.AT_LEAST_ONE,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetCarbonTransport")
     protected void setCarbonTransport(ServerConnector serverConnector) {
         if (serverConnector instanceof HTTPServerConnector) {
             HTTPServerConnector httpServerConnector = (HTTPServerConnector) serverConnector;

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ServerConfigurationTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ServerConfigurationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for {@link ServerConfiguration} class.
+ *
+ * @since 0.12.6
+ */
+public class ServerConfigurationTest {
+
+    @Test
+    public void testGetContextPaths() {
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        Assert.assertTrue(serverConfiguration.getContextPaths().isEmpty());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
             <!--Kernel-->
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.core</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.server.feature</artifactId>
                 <version>${carbon.kernel.version}</version>
                 <type>zip</type>
@@ -80,11 +85,6 @@
                 <artifactId>org.wso2.carbon.touchpoint.feature</artifactId>
                 <version>${carbon.touchpoint.version}</version>
                 <type>zip</type>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core</artifactId>
-                <version>${carbon.kernel.version}</version>
             </dependency>
 
             <!--Deployment-->

--- a/tests/distribution/carbon-home/conf/default/deployment.yaml
+++ b/tests/distribution/carbon-home/conf/default/deployment.yaml
@@ -34,3 +34,7 @@ wso2.securevault:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
       masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+
+wso2.carbon-ui-server:
+  contextPaths:
+    "test": "/sample"

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -61,40 +61,8 @@
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.config</groupId>
-            <artifactId>org.wso2.carbon.config.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.secvault</groupId>
-            <artifactId>org.wso2.carbon.secvault.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.utils</groupId>
-            <artifactId>org.wso2.carbon.utils.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.touchpoint</groupId>
             <artifactId>org.wso2.carbon.touchpoint.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-
-        <!--Transport-->
-        <dependency>
-            <groupId>org.wso2.carbon.messaging</groupId>
-            <artifactId>org.wso2.carbon.messaging.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.transport</groupId>
-            <artifactId>org.wso2.carbon.transport.http.netty.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.transport</groupId>
-            <artifactId>org.wso2.carbon.connector.framework.feature</artifactId>
             <type>zip</type>
         </dependency>
 
@@ -110,10 +78,43 @@
             <type>zip</type>
         </dependency>
 
+        <!--Config-->
+        <dependency>
+            <groupId>org.wso2.carbon.config</groupId>
+            <artifactId>org.wso2.carbon.config.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.secvault</groupId>
+            <artifactId>org.wso2.carbon.secvault.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.utils</groupId>
+            <artifactId>org.wso2.carbon.utils.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+
         <!-- MSF4J -->
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>org.wso2.msf4j.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+        <!--Transport-->
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.transport</groupId>
+            <artifactId>org.wso2.carbon.transport.http.netty.feature</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.transport</groupId>
+            <artifactId>org.wso2.carbon.connector.framework.feature</artifactId>
             <type>zip</type>
         </dependency>
         <!--Metrics-->
@@ -212,10 +213,6 @@
 
                                 <!--Kernel-->
                                 <feature>
-                                    <id>org.wso2.carbon.touchpoint.feature</id>
-                                    <version>${carbon.touchpoint.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.server.feature</id>
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
@@ -227,6 +224,22 @@
                                     <id>org.wso2.carbon.osgi.feature</id>
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.touchpoint.feature</id>
+                                    <version>${carbon.touchpoint.version}</version>
+                                </feature>
+
+                                <!--Deployment-->
+                                <feature>
+                                    <id>org.wso2.carbon.deployment.engine.feature</id>
+                                    <version>${carbon.deployment.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.deployment.notifier.feature</id>
+                                    <version>${carbon.deployment.version}</version>
+                                </feature>
+
+                                <!--Config-->
                                 <feature>
                                     <id>org.wso2.carbon.config.feature</id>
                                     <version>${carbon.config.version}</version>
@@ -240,6 +253,11 @@
                                     <version>${carbon.utils.version}</version>
                                 </feature>
 
+                                <!--MSF4J-->
+                                <feature>
+                                    <id>org.wso2.msf4j.feature</id>
+                                    <version>${msf4j.version}</version>
+                                </feature>
                                 <!--Transport-->
                                 <feature>
                                     <id>org.wso2.carbon.messaging.feature</id>
@@ -252,22 +270,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.connector.framework.feature</id>
                                     <version>${carbon.transport.version}</version>
-                                </feature>
-
-                                <!--Deployment-->
-                                <feature>
-                                    <id>org.wso2.carbon.deployment.engine.feature</id>
-                                    <version>${carbon.deployment.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.deployment.notifier.feature</id>
-                                    <version>${carbon.deployment.version}</version>
-                                </feature>
-
-                                <!--MSF4J-->
-                                <feature>
-                                    <id>org.wso2.msf4j.feature</id>
-                                    <version>${msf4j.version}</version>
                                 </feature>
                                 <!--Metrics-->
                                 <feature>
@@ -352,6 +354,35 @@
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
 
+                                <!--Deployment-->
+                                <feature>
+                                    <id>org.wso2.carbon.deployment.engine.feature</id>
+                                    <version>${carbon.deployment.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.deployment.notifier.feature</id>
+                                    <version>${carbon.deployment.version}</version>
+                                </feature>
+
+                                <!--Config-->
+                                <feature>
+                                    <id>org.wso2.carbon.config.feature</id>
+                                    <version>${carbon.config.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.secvault.feature</id>
+                                    <version>${carbon.securevault.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.utils.feature</id>
+                                    <version>${carbon.utils.version}</version>
+                                </feature>
+
+                                <!--MSF4J-->
+                                <feature>
+                                    <id>org.wso2.msf4j.feature</id>
+                                    <version>${msf4j.version}</version>
+                                </feature>
                                 <!--Transport-->
                                 <feature>
                                     <id>org.wso2.carbon.messaging.feature</id>
@@ -364,22 +395,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.connector.framework.feature</id>
                                     <version>${carbon.transport.version}</version>
-                                </feature>
-
-                                <!--Deployment-->
-                                <feature>
-                                    <id>org.wso2.carbon.deployment.engine.feature</id>
-                                    <version>${carbon.deployment.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.deployment.notifier.feature</id>
-                                    <version>${carbon.deployment.version}</version>
-                                </feature>
-
-                                <!--MSF4J-->
-                                <feature>
-                                    <id>org.wso2.msf4j.feature</id>
-                                    <version>${msf4j.version}</version>
                                 </feature>
                                 <!--Metrics-->
                                 <feature>


### PR DESCRIPTION
## Purpose
Fixes #47 

## Approach
Load Carbon UI Server configurations to `ServerConfiguration` from `deployment.yaml`.

## Documentation
`deployment.yaml`:

```yaml
wso2.carbon-ui-server:
    contextPaths:
        "portal": "my-dashboard"
        "monitor": "sys-status"
```

## Automation tests
 - Unit tests 
   - Added tests for `org.wso2.carbon.uis.api.ServerConfiguration` class.
   - Coverage: 42%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
See `tests/distribution/carbon-home/conf/default/deployment.yaml`
