### PR TITLE
Make `HttpResponse` class immutable

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.12.7-SNAPSHOT</version>
+        <version>0.13.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/http/HttpResponse.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/http/HttpResponse.java
@@ -18,15 +18,8 @@
 
 package org.wso2.carbon.uis.api.http;
 
-import org.apache.commons.io.FilenameUtils;
-
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Represents a HTTP response.
@@ -63,113 +56,45 @@ public class HttpResponse {
     private int status;
     private Object content;
     private String contentType;
-    private MultivaluedMap<String, String> headers;
+    private Map<String, String> headers;
     private Map<String, String> cookies;
 
-    public HttpResponse() {
-        this.status = 200;
-        this.headers = new MultivaluedHashMap<>();
-        this.cookies = new HashMap<>();
-    }
-
     /**
-     * Sets the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP status code</a> of this response to the
-     * specified integer.
+     * Creates a new response.
      *
-     * @param statusCode HTTP status code to be set
+     * @param status      HTTP statusCode code of the response
+     * @param content     content of the response
+     * @param contentType MIME type of the response
      */
-    public void setStatus(int statusCode) {
-        this.status = statusCode;
+    public HttpResponse(int status, Object content, String contentType) {
+        this(status, content, contentType, Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**
-     * Returns the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP status code</a> of this response.
+     * Creates a new response.
      *
-     * @return HTTP status code of this response
+     * @param status      HTTP statusCode code of the response
+     * @param content     content of the response
+     * @param contentType MIME type of the response
+     * @param headers     HTTP headers of the response
+     * @param cookies     cookies of the response
+     */
+    public HttpResponse(int status, Object content, String contentType,
+                        Map<String, String> headers, Map<String, String> cookies) {
+        this.status = status;
+        this.content = content;
+        this.contentType = contentType;
+        this.headers = Collections.unmodifiableMap(headers);
+        this.cookies = Collections.unmodifiableMap(cookies);
+    }
+
+    /**
+     * Returns the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP statusCode code</a> of this response.
+     *
+     * @return HTTP statusCode code of this response
      */
     public int getStatus() {
         return status;
-    }
-
-    /**
-     * Sets the specified textual content to this response. This is equivalent to
-     * {@code setContent(content, }{@link #CONTENT_TYPE_TEXT_PLAIN}{@code )}
-     *
-     * @param content textual content to be set
-     * @see #setContent(String, String)
-     */
-    public void setContent(String content) {
-        setContent(content, CONTENT_TYPE_TEXT_PLAIN);
-    }
-
-    /**
-     * Sets the specified textual content and the content type to this response.
-     *
-     * @param content     textual content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(String content, String contentType) {
-        setContent((Object) content, contentType);
-    }
-
-    /**
-     * Sets the file content located by the specified path to this response.
-     *
-     * @param content path of the file content to be set
-     */
-    public void setContent(Path content) {
-        setContent(content.toFile());
-    }
-
-    /**
-     * Sets the file content located by the specified path and the content type to this response.
-     *
-     * @param content     path of the file content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(Path content, String contentType) {
-        setContent(content.toFile(), contentType);
-    }
-
-    /**
-     * Sets the specified file content to this response.
-     *
-     * @param content file content to be set
-     */
-    public void setContent(File content) {
-        String extension = FilenameUtils.getExtension(content.getName());
-        setContent(content, extension.isEmpty() ? CONTENT_TYPE_WILDCARD : extension);
-    }
-
-    /**
-     * Sets the specified file content and the content type to this response.
-     *
-     * @param content     file content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(File content, String contentType) {
-        setContent((Object) content, contentType);
-    }
-
-    /**
-     * Sets the content read through the specified input stream and the content type to this response.
-     *
-     * @param content     input stream to the content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(InputStream content, String contentType) {
-        setContent((Object) content, contentType);
-    }
-
-    /**
-     * Sets the specified content and the content type to this response.
-     *
-     * @param content     content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(Object content, String contentType) {
-        this.content = content;
-        this.contentType = contentType;
     }
 
     /**
@@ -192,55 +117,12 @@ public class HttpResponse {
     }
 
     /**
-     * Sets the specified the HTTP status code and the textual content to this response.
-     *
-     * @param statusCode HTTP status code to be set
-     * @param content    textual content to be set
-     */
-    public void setContent(int statusCode, String content) {
-        setStatus(statusCode);
-        setContent(content);
-    }
-
-    /**
-     * Sets the specified the HTTP status code and the textual content to this response.
-     *
-     * @param statusCode  HTTP status code to be set
-     * @param content     textual content to be set
-     * @param contentType MIME type of the content
-     */
-    public void setContent(int statusCode, String content, String contentType) {
-        setStatus(statusCode);
-        setContent(content, contentType);
-    }
-
-    /**
-     * Adds a new value to the specified HTTP header of this response.
-     *
-     * @param name  name of the HTTP header
-     * @param value value to be added; if {@code null} existing value(s) will be removed
-     */
-    public void setHeader(String name, String value) {
-        headers.add(name, value);
-    }
-
-    /**
      * Returns the HTTP headers of this response.
      *
      * @return HTTP headers of this response.
      */
-    public MultivaluedMap<String, String> getHeaders() {
+    public Map<String, String> getHeaders() {
         return headers;
-    }
-
-    /**
-     * Adds a cookie to this response.
-     *
-     * @param name  name of the cookie
-     * @param value value of the cookie
-     */
-    public void addCookie(String name, String value) {
-        cookies.put(name, value);
     }
 
     /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/ResponseBuilder.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/ResponseBuilder.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * Builder for {@link HttpResponse} class.
  *
- * @since 0.12.7
+ * @since 0.13.0
  */
 public class ResponseBuilder {
 

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/ResponseBuilder.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/ResponseBuilder.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.http;
+
+import org.wso2.carbon.uis.api.http.HttpResponse;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder for {@link HttpResponse} class.
+ *
+ * @since 0.12.7
+ */
+public class ResponseBuilder {
+
+    private int status;
+    private Object content;
+    private String contentType;
+    private Map<String, String> headers = new HashMap<>();
+    private Map<String, String> cookies = new HashMap<>();
+
+    /**
+     * Sets the HTTP status code of the building response.
+     *
+     * @param status HTTP status code to be set
+     * @return the updated response builder
+     */
+    public ResponseBuilder statusCode(int status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Sets the content of the building response.
+     *
+     * @param content content to be set
+     * @return the updated response builder
+     */
+    public ResponseBuilder content(Object content) {
+        this.content = content;
+        return this;
+    }
+
+    /**
+     * Sets the MIME type of the building response.
+     *
+     * @param contentType MIME type to be set
+     * @return the updated response builder
+     */
+    public ResponseBuilder contentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    /**
+     * Sets a HTTP header of the building response.
+     *
+     * @param name  name of the HTTP header
+     * @param value value of the HTTP header
+     * @return the updated response builder
+     */
+    public ResponseBuilder header(String name, String value) {
+        this.headers.put(name, value);
+        return this;
+    }
+
+    /**
+     * Sets HTTP headers of the building response.
+     *
+     * @param headers HTTP headers (name, value pairs) to be set
+     * @return the updated response builder
+     */
+    public ResponseBuilder headers(Map<String, String> headers) {
+        headers.forEach(this::header);
+        return this;
+    }
+
+    /**
+     * Sets cookie of the building response.
+     *
+     * @param name  name of the cookie
+     * @param value value of the cookie
+     * @return the updated response builder
+     */
+    public ResponseBuilder cookie(String name, String value) {
+        this.cookies.put(name, value);
+        return this;
+    }
+
+    /**
+     * Sets cookies of the building response.
+     *
+     * @param cookies cookies name, value pairs) to be set
+     * @return the updated response builder
+     */
+    public ResponseBuilder cookies(Map<String, String> cookies) {
+        cookies.forEach(this::cookie);
+        return this;
+    }
+
+    /**
+     * Build a HTTP response.
+     *
+     * @return response
+     */
+    public HttpResponse build() {
+        return new HttpResponse(status, content, contentType, headers, cookies);
+    }
+
+    /**
+     * Creates a new response builder with the specified HTTP status code.
+     *
+     * @param status HTTP status code
+     * @return a new response builder
+     */
+    public static ResponseBuilder status(int status) {
+        return new ResponseBuilder().statusCode(status);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok() {
+        return status(HttpResponse.STATUS_OK);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @param content content of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok(String content) {
+        return ok(content, HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @param content     content of the response
+     * @param contentType MIME type of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok(String content, String contentType) {
+        return ok().content(content).contentType(contentType);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @param content     content of the response
+     * @param contentType MIME type of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok(File content, String contentType) {
+        return ok().content(content).contentType(contentType);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @param content     content of the response
+     * @param contentType MIME type of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok(Path content, String contentType) {
+        return ok(content.toFile(), contentType);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_OK OK} status.
+     *
+     * @param content     content of the response
+     * @param contentType MIME type of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder ok(InputStream content, String contentType) {
+        return ok().content(content).contentType(contentType);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_BAD_REQUEST BAD_REQUEST} status.
+     *
+     * @return a new response builder
+     */
+    public static ResponseBuilder badRequest() {
+        return status(HttpResponse.STATUS_BAD_REQUEST);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_BAD_REQUEST BAD_REQUEST} status.
+     *
+     * @param content content of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder badRequest(String content) {
+        return badRequest().content(content).contentType(HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_NOT_FOUND NOT_FOUND} status.
+     *
+     * @return a new response builder
+     */
+    public static ResponseBuilder notFound() {
+        return status(HttpResponse.STATUS_NOT_FOUND);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_NOT_FOUND NOT_FOUND} status.
+     *
+     * @param content content of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder notFound(String content) {
+        return notFound().content(content).contentType(HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR}
+     * status.
+     *
+     * @return a new response builder
+     */
+    public static ResponseBuilder serverError() {
+        return status(HttpResponse.STATUS_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Creates a new response builder with {@link HttpResponse#STATUS_INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR}
+     * status.
+     *
+     * @param content content of the response
+     * @return a new response builder
+     */
+    public static ResponseBuilder serverError(String content) {
+        return serverError().content(content).contentType(HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/http/HttpResponseTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/http/HttpResponseTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 /**
  * Test cases for {@link HttpResponse} class.
  *
- * @since 0.12.7
+ * @since 0.13.0
  */
 public class HttpResponseTest {
 

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/http/HttpResponseTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/http/HttpResponseTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.api.http;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for {@link HttpResponse} class.
+ *
+ * @since 0.12.7
+ */
+public class HttpResponseTest {
+
+    @Test
+    public void test() {
+        HttpResponse response = new HttpResponse(HttpResponse.STATUS_OK, "some-content",
+                                                 HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+        Assert.assertEquals(response.getContent(), "some-content");
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+        Assert.assertTrue(response.getHeaders().isEmpty());
+        Assert.assertTrue(response.getCookies().isEmpty());
+        Assert.assertNotNull(response.toString());
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/ResponseBuilderTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/ResponseBuilderTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * Test cases for {@link ResponseBuilder} class.
  *
- * @since 0.12.7
+ * @since 0.13.0
  */
 public class ResponseBuilderTest {
 

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/ResponseBuilderTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/ResponseBuilderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.http;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.uis.api.http.HttpResponse;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Test cases for {@link ResponseBuilder} class.
+ *
+ * @since 0.12.7
+ */
+public class ResponseBuilderTest {
+
+    @Test
+    public void testHeaders() {
+        Map<String, String> headers = Collections.singletonMap("some-header", "some-value");
+        HttpResponse response = new ResponseBuilder().statusCode(HttpResponse.STATUS_OK)
+                .headers(headers)
+                .build();
+
+        Assert.assertEquals(response.getHeaders(), headers);
+    }
+
+    @Test
+    public void testCookies() {
+        Map<String, String> cookies = Collections.singletonMap("some-cookie", "some-value");
+        HttpResponse response = new ResponseBuilder().statusCode(HttpResponse.STATUS_OK)
+                .cookies(cookies)
+                .build();
+
+        Assert.assertEquals(response.getCookies(), cookies);
+    }
+
+    @Test
+    public void testOk() {
+        HttpResponse response = ResponseBuilder.ok().build();
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+    }
+
+    @Test
+    public void testOkString() {
+        final String content = "<p>everything ok</p>";
+        HttpResponse response = ResponseBuilder.ok(content, HttpResponse.CONTENT_TYPE_TEXT_HTML).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+        Assert.assertEquals(response.getContent(), content);
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_HTML);
+    }
+
+    @Test
+    public void testOkPath() {
+        final Path content = Paths.get("src/resources/apps/full-app/public/css/styles.css");
+        HttpResponse response = ResponseBuilder.ok(content, HttpResponse.CONTENT_TYPE_TEXT_PLAIN).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+        Assert.assertEquals(response.getContent(), content.toFile());
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    @Test
+    public void testOkInputStream() {
+        final InputStream content = Mockito.mock(InputStream.class);
+        HttpResponse response = ResponseBuilder.ok(content, HttpResponse.CONTENT_TYPE_TEXT_PLAIN).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+        Assert.assertEquals(response.getContent(), content);
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    @Test
+    public void testBadRequest() {
+        final String content = "some bad request";
+        HttpResponse response = ResponseBuilder.badRequest(content).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_BAD_REQUEST);
+        Assert.assertEquals(response.getContent(), content);
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    @Test
+    public void testNotFound() {
+        final String content = "some resource/page not found";
+        HttpResponse response = ResponseBuilder.notFound(content).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_NOT_FOUND);
+        Assert.assertEquals(response.getContent(), content);
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+
+    @Test
+    public void testServerError() {
+        final String content = "some internal server error";
+        HttpResponse response = ResponseBuilder.serverError(content).build();
+
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_INTERNAL_SERVER_ERROR);
+        Assert.assertEquals(response.getContent(), content);
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticResolverTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticResolverTest.java
@@ -41,8 +41,7 @@ public class StaticResolverTest {
 
     @Test
     public void testServeDefaultFavicon() {
-        final HttpResponse response = new HttpResponse();
-        new StaticResolver().serveDefaultFavicon(null, response);
+        final HttpResponse response = new StaticResolver().serveDefaultFavicon(null);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_IMAGE_PNG);
@@ -63,8 +62,7 @@ public class StaticResolverTest {
 
     @Test(dataProvider = "invalidUris")
     public void testServeWithInvalidUri(HttpRequest request) {
-        final HttpResponse response = new HttpResponse();
-        new StaticResolver().serve(creatApp(), request, response);
+        final HttpResponse response = new StaticResolver().serve(creatApp(), request);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_BAD_REQUEST);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.12.7-SNAPSHOT</version>
+        <version>0.13.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.wso2.carbon.uis</groupId>
     <artifactId>uis-parent</artifactId>
-    <version>0.12.7-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WSO2 Carbon UI Server - Parent</name>
@@ -381,7 +381,7 @@
     </build>
 
     <properties>
-        <carbon.uis.version>0.12.7-SNAPSHOT</carbon.uis.version>
+        <carbon.uis.version>0.13.0-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
         <carbon.kernel.version>5.2.0</carbon.kernel.version>

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>0.12.7-SNAPSHOT</version>
+        <version>0.13.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.12.7-SNAPSHOT</version>
+        <version>0.13.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
Currently `org.wso2.carbon.uis.api.http.HttpResponse` class is not immutable, which might lead to concurrent issues.

## Goals
Make `HttpResponse` class immutable.

## Approach
- Removed all getters from `HttpResponse`.
- Added `org.wso2.carbon.uis.internal.http.ResponseBuilder` class for convenience.
- Bumped repo version to `0.13.0`.

## Automation tests
 - Unit tests 
   Added unit tests for `HttpResponse`, `ResponseBuilder` classes.
   Code coverage: 45%
 - Integration tests
  N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
