### PR TITLE
Make having a page mandatory in a web app to be deployed

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/reference/ArtifactAppReference.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/reference/ArtifactAppReference.java
@@ -64,16 +64,19 @@ public class ArtifactAppReference implements AppReference {
     public Set<PageReference> getPageReferences() throws FileOperationException {
         Path pages = getPagesDirectory();
         if (!Files.exists(pages)) {
-            return Collections.emptySet();
+            throw new FileOperationException(
+                    "Cannot find '" + DIR_NAME_PAGES + "' directory in app '" + appDirectory + "'.");
         }
+        Set<PageReference> pageReferences;
         try {
-            return Files.walk(pages)
+            pageReferences = Files.walk(pages)
                     .filter(Files::isRegularFile)
                     .map(pageFile -> new ArtifactPageReference(pageFile, this))
                     .collect(Collectors.toSet());
         } catch (IOException e) {
             throw new FileOperationException("An error occurred while listing pages in '" + pages + "'.", e);
         }
+        return pageReferences;
     }
 
     @Override

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/deployment/AppCreatorTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/deployment/AppCreatorTest.java
@@ -22,6 +22,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.internal.exception.AppCreationException;
 import org.wso2.carbon.uis.internal.io.reference.ArtifactAppReference;
 import org.wso2.carbon.uis.internal.reference.AppReference;
 
@@ -38,8 +39,7 @@ public class AppCreatorTest {
     public Object[][] appReferences() {
         return new Object[][]{
                 {new ArtifactAppReference(Paths.get("src/test/resources/apps/full-app/"))},
-                {new ArtifactAppReference(Paths.get("src/test/resources/apps/minimal-app/"))},
-                {new ArtifactAppReference(Paths.get("src/test/resources/apps/empty-app/"))}
+                {new ArtifactAppReference(Paths.get("src/test/resources/apps/minimal-app/"))}
         };
     }
 
@@ -47,5 +47,12 @@ public class AppCreatorTest {
     public void testCreateApp(AppReference appReference) {
         App app = AppCreator.createApp(appReference, "/test");
         Assert.assertNotNull(app);
+    }
+
+    @Test
+    public void testCreateAppWithEmptyDirectory() {
+        AppReference appReference = new ArtifactAppReference(Paths.get("src/test/resources/apps/empty-app/"));
+        Assert.assertThrows(AppCreationException.class,
+                            () -> AppCreator.createApp(appReference, "/test"));
     }
 }


### PR DESCRIPTION
## Purpose
Fixes #52

## Goals
If a web app does not have the `pages` directory or any pages, then do not deploy that web app.

## Approach
 - If `pages` directory is missing, throw a file operation exception.
 - If there are no pages, then throw an app creation exception.

## Automation tests
 - Unit tests 
   Improved `AppCreatorTest`
   Code coverage: 45%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
