### PR TITLE
Update Google gson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,8 +432,8 @@
         <netty.version.range>[4.0.30, 5.0.0)</netty.version.range>
         <guava.version>18.0</guava.version>
         <guava.version.range>[18.0,19.0)</guava.version.range>
-        <gson.version>2.6.2</gson.version>
-        <gson.version.range>[2.6.2,3)</gson.version.range>
+        <gson.version>2.7</gson.version>
+        <gson.version.range>[2.6, 3.0)</gson.version.range>
         <snakeyaml.version>1.19</snakeyaml.version>
         <snakeyaml.version.range>[1.19.0, 2.0.0)</snakeyaml.version.range>
         <org.apache.commons.commons-lang3.version>3.1</org.apache.commons.commons-lang3.version>


### PR DESCRIPTION
## Purpose
- Update the gson package version to 2.7 and update the version rage upto 3.0

## Goals
- To fix the OSGI Gson bundle conflicts with APIM 3.0.0

## Test environment
- java version "1.8.0_151"
- APIM 3.0 M9
- Ubuntu 16.04.3 LTS (xenial)