### PR TITLE
Refactoring HTTP request dispatching logic

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/App.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/App.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.uis.api;
 
 import org.wso2.carbon.uis.api.exception.PageNotFoundException;
 import org.wso2.carbon.uis.api.exception.PageRedirectException;
+import org.wso2.carbon.uis.api.exception.RenderingException;
 import org.wso2.carbon.uis.api.http.HttpRequest;
 import org.wso2.carbon.uis.api.util.Multilocational;
 import org.wso2.carbon.uis.api.util.Overridable;
@@ -185,9 +186,12 @@ public class App implements Multilocational, Overridable<App> {
      *
      * @param request HTTP request for the page
      * @return HTML content of the page
+     * @throws RenderingException    if an error occurred when rendering the page
      * @throws PageNotFoundException if there is no page matching for the HTTP request
+     * @throws PageRedirectException if a page redirection happens
      */
-    public String renderPage(HttpRequest request) throws PageNotFoundException {
+    public String renderPage(HttpRequest request)
+            throws RenderingException, PageNotFoundException, PageRedirectException {
         String uriWithoutContextPath = request.getUriWithoutContextPath();
         Page matchingPage = getMatchingPage(uriWithoutContextPath);
         if (matchingPage != null) {

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Page.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Page.java
@@ -63,10 +63,9 @@ public abstract class Page implements Comparable<Page> {
     /**
      * Renders this page and returns a HTML document.
      *
-     *
-     * @param request
-     * @param configuration
-     * @return html
+     * @param request HTTP request
+     * @param configuration configurations of the app
+     * @return output html of page rendering
      * @throws RenderingException if an error occurred during page rendering
      */
     public abstract String render(HttpRequest request, Configuration configuration) throws RenderingException;

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.uis.api.exception.UISRuntimeException;
 import org.wso2.carbon.uis.api.http.HttpRequest;
 import org.wso2.carbon.uis.api.http.HttpResponse;
 import org.wso2.carbon.uis.internal.http.ResponseBuilder;
-import org.wso2.carbon.uis.internal.io.StaticResolver;
+import org.wso2.carbon.uis.internal.io.StaticRequestDispatcher;
 
 import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_HTML;
 import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_PLAIN;
@@ -45,7 +45,7 @@ public class RequestDispatcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestDispatcher.class);
 
     private final App app;
-    private final StaticResolver staticResolver;
+    private final StaticRequestDispatcher staticRequestDispatcher;
 
     /**
      * Creates a new request dispatcher.
@@ -53,12 +53,12 @@ public class RequestDispatcher {
      * @param app web app to be served
      */
     public RequestDispatcher(App app) {
-        this(app, new StaticResolver());
+        this(app, new StaticRequestDispatcher());
     }
 
-    RequestDispatcher(App app, StaticResolver staticResolver) {
+    RequestDispatcher(App app, StaticRequestDispatcher staticRequestDispatcher) {
         this.app = app;
-        this.staticResolver = staticResolver;
+        this.staticRequestDispatcher = staticRequestDispatcher;
     }
 
     /**
@@ -81,7 +81,7 @@ public class RequestDispatcher {
     private HttpResponse serve(App app, HttpRequest request) {
         try {
             if (request.isStaticResourceRequest()) {
-                return staticResolver.serve(app, request);
+                return staticRequestDispatcher.serve(app, request);
             } else {
                 return servePage(app, request);
             }
@@ -132,6 +132,6 @@ public class RequestDispatcher {
     }
 
     private HttpResponse serveDefaultFavicon(HttpRequest request) {
-        return staticResolver.serveDefaultFavicon(request);
+        return staticRequestDispatcher.serveDefaultFavicon(request);
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
@@ -53,7 +53,7 @@ public class RequestDispatcher {
      * @param app web app to be served
      */
     public RequestDispatcher(App app) {
-        this(app, new StaticRequestDispatcher());
+        this(app, new StaticRequestDispatcher(app));
     }
 
     RequestDispatcher(App app, StaticRequestDispatcher staticRequestDispatcher) {
@@ -81,7 +81,7 @@ public class RequestDispatcher {
     private HttpResponse serve(App app, HttpRequest request) {
         try {
             if (request.isStaticResourceRequest()) {
-                return staticRequestDispatcher.serve(app, request);
+                return staticRequestDispatcher.serve(request);
             } else {
                 return servePage(app, request);
             }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java
@@ -21,19 +21,12 @@ package org.wso2.carbon.uis.internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uis.api.App;
-import org.wso2.carbon.uis.api.exception.HttpErrorException;
-import org.wso2.carbon.uis.api.exception.PageRedirectException;
 import org.wso2.carbon.uis.api.exception.UISRuntimeException;
 import org.wso2.carbon.uis.api.http.HttpRequest;
 import org.wso2.carbon.uis.api.http.HttpResponse;
+import org.wso2.carbon.uis.internal.http.PageRequestDispatcher;
 import org.wso2.carbon.uis.internal.http.ResponseBuilder;
 import org.wso2.carbon.uis.internal.io.StaticRequestDispatcher;
-
-import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_HTML;
-import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_PLAIN;
-import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_LOCATION;
-import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_BAD_REQUEST;
-import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
 
 /**
  * Dispatches HTTP requests.
@@ -44,7 +37,7 @@ public class RequestDispatcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestDispatcher.class);
 
-    private final App app;
+    private final PageRequestDispatcher pageRequestDispatcher;
     private final StaticRequestDispatcher staticRequestDispatcher;
 
     /**
@@ -53,11 +46,11 @@ public class RequestDispatcher {
      * @param app web app to be served
      */
     public RequestDispatcher(App app) {
-        this(app, new StaticRequestDispatcher(app));
+        this(new PageRequestDispatcher(app), new StaticRequestDispatcher(app));
     }
 
-    RequestDispatcher(App app, StaticRequestDispatcher staticRequestDispatcher) {
-        this.app = app;
+    RequestDispatcher(PageRequestDispatcher pageRequestDispatcher, StaticRequestDispatcher staticRequestDispatcher) {
+        this.pageRequestDispatcher = pageRequestDispatcher;
         this.staticRequestDispatcher = staticRequestDispatcher;
     }
 
@@ -69,69 +62,23 @@ public class RequestDispatcher {
      */
     public HttpResponse serve(HttpRequest request) {
         if (!request.isValid()) {
-            return serveDefaultErrorPage(STATUS_BAD_REQUEST, "Invalid URI '" + request.getUri() + "'.");
-        }
-        if (request.isDefaultFaviconRequest()) {
-            return serveDefaultFavicon(request);
+            return ResponseBuilder.badRequest("URI '" + request.getUri() + "' is invalid.").build();
         }
 
-        return serve(app, request);
-    }
-
-    private HttpResponse serve(App app, HttpRequest request) {
         try {
-            if (request.isStaticResourceRequest()) {
+            if (request.isDefaultFaviconRequest()) {
+                return staticRequestDispatcher.serveDefaultFavicon(request);
+            } else if (request.isStaticResourceRequest()) {
                 return staticRequestDispatcher.serve(request);
             } else {
-                return servePage(app, request);
+                return pageRequestDispatcher.serve(request);
             }
-        } catch (PageRedirectException e) {
-            return ResponseBuilder.status(e.getHttpStatusCode())
-                    .header(HEADER_LOCATION, e.getRedirectUrl())
-                    .build();
-        } catch (HttpErrorException e) {
-            return serveDefaultErrorPage(e.getHttpStatusCode(), e.getMessage());
         } catch (UISRuntimeException e) {
-            String msg = "A server error occurred while serving for request '" + request + "'.";
-            LOGGER.error(msg, e);
-            return serveDefaultErrorPage(STATUS_INTERNAL_SERVER_ERROR, msg);
+            LOGGER.error("An error occurred when serving for request '{}'.", request, e);
+            return ResponseBuilder.serverError("A server occurred while serving for request.").build();
         } catch (Exception e) {
-            String msg = "An unexpected error occurred while serving for request '" + request + "'.";
-            LOGGER.error(msg, e);
-            return serveDefaultErrorPage(STATUS_INTERNAL_SERVER_ERROR, msg);
+            LOGGER.error("An unexpected error occurred when serving for request '{}'.", request, e);
+            return ResponseBuilder.serverError("An unexpected server occurred while serving for request.").build();
         }
-    }
-
-    private HttpResponse servePage(App app, HttpRequest request) {
-        try {
-            String html = app.renderPage(request);
-            return ResponseBuilder.ok(html, CONTENT_TYPE_TEXT_HTML)
-                    .headers(app.getConfiguration().getResponseHeaders().forPages())
-                    .build();
-        } catch (UISRuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            // May be an UISRuntimeException cause this 'e' Exception. Let's unwrap 'e' and find out.
-            Throwable th = e;
-            while ((th = th.getCause()) != null) {
-                if (th instanceof UISRuntimeException) {
-                    // Cause of 'e' is an UISRuntimeException. Throw 'th' so that we can handle it properly.
-                    throw (UISRuntimeException) th;
-                }
-            }
-            // Cause of 'e' is not an UISRuntimeException.
-            throw e;
-        }
-    }
-
-    private HttpResponse serveDefaultErrorPage(int httpStatusCode, String content) {
-        return ResponseBuilder.status(httpStatusCode)
-                .content(content)
-                .contentType(CONTENT_TYPE_TEXT_PLAIN)
-                .build();
-    }
-
-    private HttpResponse serveDefaultFavicon(HttpRequest request) {
-        return staticRequestDispatcher.serveDefaultFavicon(request);
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/BadRequestException.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/BadRequestException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.exception;
+
+import org.wso2.carbon.uis.api.exception.HttpErrorException;
+import org.wso2.carbon.uis.api.http.HttpResponse;
+
+/**
+ * Indicates a bad/invalid HTTP request.
+ *
+ * @since 0.13.4
+ */
+public class BadRequestException extends HttpErrorException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message.
+     */
+    public BadRequestException() {
+        super(HttpResponse.STATUS_BAD_REQUEST);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message detail message
+     */
+    public BadRequestException(String message) {
+        super(HttpResponse.STATUS_BAD_REQUEST, message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message details message
+     * @param cause   the cause of the exception
+     */
+    public BadRequestException(String message, Throwable cause) {
+        super(HttpResponse.STATUS_BAD_REQUEST, message, cause);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/PageRequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/PageRequestDispatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.api.exception.HttpErrorException;
+import org.wso2.carbon.uis.api.exception.PageRedirectException;
+import org.wso2.carbon.uis.api.exception.UISRuntimeException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+import org.wso2.carbon.uis.api.http.HttpResponse;
+
+import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_HTML;
+import static org.wso2.carbon.uis.api.http.HttpResponse.CONTENT_TYPE_TEXT_PLAIN;
+import static org.wso2.carbon.uis.api.http.HttpResponse.HEADER_LOCATION;
+import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
+
+public class PageRequestDispatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PageRequestDispatcher.class);
+
+    private final App app;
+
+    public PageRequestDispatcher(App app) {
+        this.app = app;
+    }
+
+    public HttpResponse server(HttpRequest request) {
+        try {
+            String html = app.renderPage(request);
+            return ResponseBuilder.ok(html, CONTENT_TYPE_TEXT_HTML)
+                    .headers(app.getConfiguration().getResponseHeaders().forPages())
+                    .build();
+        } catch (PageRedirectException e) {
+            return ResponseBuilder.status(e.getHttpStatusCode())
+                    .header(HEADER_LOCATION, e.getRedirectUrl())
+                    .build();
+        } catch (HttpErrorException e) {
+            return serveDefaultErrorPage(e.getHttpStatusCode(), e.getMessage());
+        } catch (UISRuntimeException e) {
+            LOGGER.error("Cannot serve request {} due to a runtime exception in the server.", request, e);
+            return serveDefaultErrorPage(STATUS_INTERNAL_SERVER_ERROR, "Internal server error.");
+        }
+    }
+
+    private static HttpResponse serveDefaultErrorPage(int httpStatusCode, String content) {
+        return ResponseBuilder.status(httpStatusCode)
+                .content(content)
+                .contentType(CONTENT_TYPE_TEXT_PLAIN)
+                .build();
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcher.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcher.java
@@ -64,11 +64,11 @@ import static org.wso2.carbon.uis.api.http.HttpResponse.STATUS_NOT_MODIFIED;
  *
  * @since 0.8.0
  */
-public class StaticResolver {
+public class StaticRequestDispatcher {
 
     private static final DateTimeFormatter HTTP_DATE_FORMATTER;
     private static final ZoneId GMT_TIME_ZONE;
-    private static final Logger LOGGER = LoggerFactory.getLogger(StaticResolver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StaticRequestDispatcher.class);
 
     private final Map<Path, ZonedDateTime> resourcesLastModifiedDates;
 
@@ -81,7 +81,7 @@ public class StaticResolver {
     /**
      * Constructs a new static request dispatcher.
      */
-    public StaticResolver() {
+    public StaticRequestDispatcher() {
         if (false) {
             /*
              * When the dev mode is enabled, we do not cache last modified dates of serving static resources. This is

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/RequestDispatcherTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/RequestDispatcherTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.uis.api.exception.UISRuntimeException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+import org.wso2.carbon.uis.api.http.HttpResponse;
+import org.wso2.carbon.uis.internal.http.PageRequestDispatcher;
+import org.wso2.carbon.uis.internal.io.StaticRequestDispatcher;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link RequestDispatcher} class.
+ *
+ * @since 0.13.4
+ */
+public class RequestDispatcherTest {
+
+    @Test
+    public void testServeInvalidRequest() {
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.isValid()).thenReturn(false);
+
+        HttpResponse response = new RequestDispatcher(null).serve(request);
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_BAD_REQUEST);
+        Assert.assertNotNull(response.getContent());
+    }
+
+    @Test
+    public void testServeFaviconRequest() {
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.isValid()).thenReturn(true);
+        when(request.isDefaultFaviconRequest()).thenReturn(true);
+        StaticRequestDispatcher staticRequestDispatcher = mock(StaticRequestDispatcher.class);
+
+        new RequestDispatcher(null, staticRequestDispatcher).serve(request);
+        verify(staticRequestDispatcher).serveDefaultFavicon(request);
+    }
+
+    @Test
+    public void testServeStaticRequest() {
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.isValid()).thenReturn(true);
+        when(request.isDefaultFaviconRequest()).thenReturn(false);
+        when(request.isStaticResourceRequest()).thenReturn(true);
+        StaticRequestDispatcher staticRequestDispatcher = mock(StaticRequestDispatcher.class);
+
+        new RequestDispatcher(null, staticRequestDispatcher).serve(request);
+        verify(staticRequestDispatcher).serve(request);
+    }
+
+    @Test
+    public void testServePageRequest() {
+        HttpRequest request = createPageRequest();
+        PageRequestDispatcher pageRequestDispatcher = mock(PageRequestDispatcher.class);
+
+        new RequestDispatcher(pageRequestDispatcher, null).serve(request);
+        verify(pageRequestDispatcher).serve(request);
+    }
+
+    @Test
+    public void testServeWhenUISRuntimeException() {
+        HttpRequest request = createPageRequest();
+        PageRequestDispatcher pageRequestDispatcher = mock(PageRequestDispatcher.class);
+        when(pageRequestDispatcher.serve(any())).thenThrow(UISRuntimeException.class);
+
+        HttpResponse response = new RequestDispatcher(pageRequestDispatcher, null).serve(request);
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_INTERNAL_SERVER_ERROR);
+        Assert.assertNotNull(response.getContent());
+    }
+
+    @Test
+    public void testServeWhenException() {
+        HttpRequest request = createPageRequest();
+        PageRequestDispatcher pageRequestDispatcher = mock(PageRequestDispatcher.class);
+        when(pageRequestDispatcher.serve(any())).thenThrow(Exception.class);
+
+        HttpResponse response = new RequestDispatcher(pageRequestDispatcher, null).serve(request);
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_INTERNAL_SERVER_ERROR);
+        Assert.assertNotNull(response.getContent());
+    }
+
+    private static HttpRequest createPageRequest() {
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.isValid()).thenReturn(true);
+        when(request.isDefaultFaviconRequest()).thenReturn(false);
+        when(request.isStaticResourceRequest()).thenReturn(false);
+        return request;
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/PageRequestDispatcherTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/PageRequestDispatcherTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.http;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.api.Configuration;
+import org.wso2.carbon.uis.api.exception.PageNotFoundException;
+import org.wso2.carbon.uis.api.exception.PageRedirectException;
+import org.wso2.carbon.uis.api.exception.RenderingException;
+import org.wso2.carbon.uis.api.http.HttpRequest;
+import org.wso2.carbon.uis.api.http.HttpResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for {@link PageRequestDispatcher} class.
+ *
+ * @since 0.13.4
+ */
+public class PageRequestDispatcherTest {
+
+    @Test
+    public void testServe() {
+        App app = mock(App.class);
+        when(app.renderPage(any())).thenReturn("<p>some html</p>");
+        when(app.getConfiguration()).thenReturn(Configuration.DEFAULT_CONFIGURATION);
+
+        HttpResponse response = new PageRequestDispatcher(app).serve(mock(HttpRequest.class));
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
+        Assert.assertEquals(response.getContent(), "<p>some html</p>");
+        Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_HTML);
+    }
+
+    @Test
+    public void testServeWithRenderingException() {
+        App app = mock(App.class);
+        when(app.renderPage(any())).thenThrow(RenderingException.class);
+
+        HttpResponse response = new PageRequestDispatcher(app).serve(mock(HttpRequest.class));
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    public void testServeWithPageNotFoundException() {
+        App app = mock(App.class);
+        when(app.renderPage(any())).thenThrow(PageNotFoundException.class);
+
+        HttpResponse response = new PageRequestDispatcher(app).serve(mock(HttpRequest.class));
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_NOT_FOUND);
+    }
+
+    @Test
+    public void testServeWithPageRedirectException() {
+        App app = mock(App.class);
+        when(app.renderPage(any())).thenThrow(new PageRedirectException("redirect/url"));
+
+        HttpResponse response = new PageRequestDispatcher(app).serve(mock(HttpRequest.class));
+        Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_FOUND);
+        Assert.assertEquals(response.getHeaders().get(HttpResponse.HEADER_LOCATION), "redirect/url");
+    }
+}

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcherTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcherTest.java
@@ -41,7 +41,7 @@ public class StaticRequestDispatcherTest {
 
     @Test
     public void testServeDefaultFavicon() {
-        final HttpResponse response = new StaticRequestDispatcher().serveDefaultFavicon(null);
+        final HttpResponse response = new StaticRequestDispatcher(null).serveDefaultFavicon(null);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_IMAGE_PNG);
@@ -62,7 +62,7 @@ public class StaticRequestDispatcherTest {
 
     @Test(dataProvider = "invalidUris")
     public void testServeWithInvalidUri(HttpRequest request) {
-        final HttpResponse response = new StaticRequestDispatcher().serve(creatApp(), request);
+        final HttpResponse response = new StaticRequestDispatcher(creatApp()).serve(request);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_BAD_REQUEST);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcherTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/io/StaticRequestDispatcherTest.java
@@ -33,15 +33,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Test cases for {@link StaticResolver} class.
+ * Test cases for {@link StaticRequestDispatcher} class.
  *
  * @since 0.12.5
  */
-public class StaticResolverTest {
+public class StaticRequestDispatcherTest {
 
     @Test
     public void testServeDefaultFavicon() {
-        final HttpResponse response = new StaticResolver().serveDefaultFavicon(null);
+        final HttpResponse response = new StaticRequestDispatcher().serveDefaultFavicon(null);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_OK);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_IMAGE_PNG);
@@ -62,7 +62,7 @@ public class StaticResolverTest {
 
     @Test(dataProvider = "invalidUris")
     public void testServeWithInvalidUri(HttpRequest request) {
-        final HttpResponse response = new StaticResolver().serve(creatApp(), request);
+        final HttpResponse response = new StaticRequestDispatcher().serve(creatApp(), request);
 
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_BAD_REQUEST);
         Assert.assertEquals(response.getContentType(), HttpResponse.CONTENT_TYPE_TEXT_PLAIN);


### PR DESCRIPTION
## Purpose
- Simplify logic in [`StaticResolver`](https://github.com/wso2/carbon-ui-server/blob/v0.13.3/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/StaticResolver.java) class and [`RequestDispatcher`](https://github.com/wso2/carbon-ui-server/blob/v0.13.3/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/RequestDispatcher.java)
- Improve test coverage on HTTP request dispatching logic
- Improve exception handling (currently some exceptions might slip-through if happens)
- Eliminate possible bugs

## Approach
-  Add `PageRequestDispatcher` class which dispatches HTTP requests for pages.
- Rename `StaticResolver` to `StaticRequestDispatcher` which dispatches HTTP requests for static resources.
- Changed logic in `RequestDispatcher` class to delegate HTTP request dispatching to `PageRequestDispatcher` or `StaticRequestDispatcher`.
- Add unit tests for `PageRequestDispatcher` and `RequestDispatcher`.
- Improved existing unit test of `StaticRequestDispatcher`.

## Automation tests
 - Unit tests 
  Code coverage: **57%**
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
