### PR TITLE
Bump Carbon Kernel version to v5.2.5

### DIFF
--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/msf4j/Msf4jHttpConnector.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/msf4j/Msf4jHttpConnector.java
@@ -117,9 +117,10 @@ public class Msf4jHttpConnector implements HttpConnector {
         httpTransports.stream()
                 .filter(httpTransport -> !app.getConfiguration().isHttpsOnly() || httpTransport.isSecured())
                 .forEach(httpTransport -> {
-                    Dictionary<String, String> properties = new Hashtable<>();
+                    Dictionary<String, Object> properties = new Hashtable<>();
                     properties.put("CHANNEL_ID", httpTransport.getId());
                     properties.put("contextPath", app.getContextPath());
+                    properties.put("skipCarbonStartupResolver", true);
                     ServiceRegistration<Microservice> serviceRegistration = bundleContext.registerService(
                             Microservice.class, new WebappMicroservice(httpListener), properties);
 

--- a/pom.xml
+++ b/pom.xml
@@ -384,8 +384,8 @@
         <carbon.uis.version>0.14.1-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
-        <carbon.kernel.version>5.2.0</carbon.kernel.version>
-        <carbon.kernel.version.range>[5.2.0, 6.0.0)</carbon.kernel.version.range>
+        <carbon.kernel.version>5.2.5</carbon.kernel.version>
+        <carbon.kernel.version.range>[5.2.5, 6.0.0)</carbon.kernel.version.range>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
 
         <!--Deployment-->


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Bumped Carbon Kenel version to v5.2.5
- Set `skipCarbonStartupResolver` to `true` when registering microservices.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
