### PR TITLE
Add an App parameter to getMicroservices() method in RestApiProvider interface

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/RestApiDeployer.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/RestApiDeployer.java
@@ -71,7 +71,7 @@ public class RestApiDeployer implements AppDeploymentEventListener {
 
         String appContextPath = app.getContextPath();
         boolean httpsOnly = app.getConfiguration().isHttpsOnly();
-        Set<MicroserviceRegistration> registrations = restApiProvider.getMicroservices().entrySet().stream()
+        Set<MicroserviceRegistration> registrations = restApiProvider.getMicroservices(app).entrySet().stream()
                 .map(entry -> registerMicroservice((appContextPath + entry.getKey()), entry.getValue(), httpsOnly))
                 .collect(Collectors.toSet());
         microserviceRegistrations.put(app.getName(), registrations);

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/spi/RestApiProvider.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/spi/RestApiProvider.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.uis.spi;
 
+import org.wso2.carbon.uis.api.App;
 import org.wso2.msf4j.Microservice;
 
 import java.util.Map;
@@ -41,7 +42,8 @@ public interface RestApiProvider {
      * <p>
      * Key of the returning map is considered as the path (without the app context path) of the REST API.
      *
+     * @param app app that returning microservices belong to
      * @return microservices to be deploy
      */
-    Map<String, Microservice> getMicroservices();
+    Map<String, Microservice> getMicroservices(App app);
 }

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/deployment/RestApiDeployerTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/deployment/RestApiDeployerTest.java
@@ -105,7 +105,8 @@ public class RestApiDeployerTest {
     private static RestApiProvider createRestApiProvider(String appName) {
         RestApiProvider restApiProvider = mock(RestApiProvider.class);
         when(restApiProvider.getAppName()).thenReturn(appName);
-        when(restApiProvider.getMicroservices()).thenReturn(Collections.singletonMap("/bar", mock(Microservice.class)));
+        when(restApiProvider.getMicroservices(any()))
+                .thenReturn(Collections.singletonMap("/bar", mock(Microservice.class)));
         return restApiProvider;
     }
 

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.wso2.carbon.uis</groupId>
     <artifactId>uis-parent</artifactId>
-    <version>0.16.1-SNAPSHOT</version>
+    <version>0.17.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WSO2 Carbon UI Server - Parent</name>
@@ -358,7 +358,7 @@
     </build>
 
     <properties>
-        <carbon.uis.version>0.16.1-SNAPSHOT</carbon.uis.version>
+        <carbon.uis.version>0.17.0-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
         <carbon.kernel.version>5.2.5</carbon.kernel.version>

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
The only way to acquire an `org.wso2.carbon.uis.api.App` object of a web app is by getting a reference to the `org.wso2.carbon.uis.spi.Server` OSGi service. `org.wso2.carbon.uis.spi.Server` OSGi service is activated after all available `org.wso2.carbon.uis.spi.RestApiProvider` are activated and `org.wso2.msf4j.MicroservicesServer` service is activated. Hence, a circular OSGi dependency can occur if a Microservice of a web app needs to get access to the associated web app object.

## Goals
A Microservice of a web app should be able to get the `org.wso2.carbon.uis.api.App` object of the associated web app.

## Approach
- Changed `Map<String, Microservice> getMicroservices()` method in `org.wso2.carbon.uis.spi.RestApiProvider` interface to `Map<String, Microservice> getMicroservices(App app)`
- Bump repo version to v0.17.0-SNAPSHOT

## Automation tests
 - Unit tests 
   Code coverage: 67%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Related PRs
#59 
