### PR TITLE
Option to deploy a web app exclusively to a configured HTTP transport

### DIFF
--- a/components/org.wso2.carbon.uis/pom.xml
+++ b/components/org.wso2.carbon.uis/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.17.3-SNAPSHOT</version>
+        <version>0.18.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/Configuration.java
@@ -43,31 +43,19 @@ public class Configuration {
      */
     public static final Configuration DEFAULT_CONFIGURATION;
 
-    private final boolean httpsOnly;
     private final HttpResponseHeaders responseHeaders;
 
     static {
-        DEFAULT_CONFIGURATION = new Configuration(false, new HttpResponseHeaders(emptyMap(), emptyMap()));
+        DEFAULT_CONFIGURATION = new Configuration(new HttpResponseHeaders(emptyMap(), emptyMap()));
     }
 
     /**
      * Creates a new configuration.
      *
-     * @param httpsOnly       whether the associated web app is HTTPS only or not.
      * @param responseHeaders HTTP response headers configuration
      */
-    public Configuration(boolean httpsOnly, HttpResponseHeaders responseHeaders) {
-        this.httpsOnly = httpsOnly;
+    public Configuration(HttpResponseHeaders responseHeaders) {
         this.responseHeaders = responseHeaders;
-    }
-
-    /**
-     * Returns whether the associated web app is HTTPS only or not.
-     *
-     * @return {@code true} if the associated web app is HTTPS only, otherwise {@code false}
-     */
-    public boolean isHttpsOnly() {
-        return httpsOnly;
     }
 
     /**

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
@@ -68,8 +68,13 @@ public class ServerConfiguration {
          * Returns the context path in this app configuration.
          *
          * @return the context path
+         * @throws IllegalArgumentException if configured context path is invalid
          */
-        public Optional<String> getContextPath() {
+        public Optional<String> getContextPath() throws IllegalArgumentException {
+            if ((contextPath != null) && (contextPath.charAt(0) != '/')) {
+                throw new IllegalArgumentException(
+                        "Configured context path '" + contextPath + "' is invalid as it does not start with a '/'.");
+            }
             return Optional.ofNullable(contextPath);
         }
 
@@ -77,8 +82,12 @@ public class ServerConfiguration {
          * Returns the transport ID in this app configuration.
          *
          * @return the transport ID
+         * @throws IllegalArgumentException if configured transport ID is invalid
          */
-        public Optional<String> getTransportId() {
+        public Optional<String> getTransportId() throws IllegalArgumentException {
+            if ((transportId != null) && !transportId.isEmpty()) {
+                throw new IllegalArgumentException("Configured transport ID is invalid as it cannot be a empty.");
+            }
             return Optional.ofNullable(transportId);
         }
     }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
@@ -85,7 +85,7 @@ public class ServerConfiguration {
          * @throws IllegalArgumentException if configured transport ID is invalid
          */
         public Optional<String> getTransportId() throws IllegalArgumentException {
-            if ((transportId != null) && !transportId.isEmpty()) {
+            if ((transportId != null) && transportId.isEmpty()) {
                 throw new IllegalArgumentException("Configured transport ID is invalid as it cannot be a empty.");
             }
             return Optional.ofNullable(transportId);

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/api/ServerConfiguration.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.config.annotation.Element;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Bean class for server configurations.
@@ -32,15 +33,53 @@ import java.util.Map;
 @Configuration(namespace = "wso2.carbon-ui-server", description = "Configurations for Carbon UI Server")
 public class ServerConfiguration {
 
-    @Element(description = "context paths for web apps")
-    private Map<String, String> contextPaths = Collections.emptyMap();
+    @Element(description = "Configurations for web apps.\n" +
+                           "Here key is the name of the web app abd value is configurations for that web app.")
+    private Map<String, AppConfiguration> apps = Collections.emptyMap();
 
     /**
-     * Returns overrding context paths for web apps.
+     * Returns configurations for the specified app.
      *
-     * @return overriding context paths
+     * @param appName name of the app
+     * @return server configurations of the app
      */
-    public Map<String, String> getContextPaths() {
-        return contextPaths;
+    public Optional<AppConfiguration> getConfigurationForApp(String appName) {
+        return Optional.ofNullable(apps.get(appName));
+    }
+
+    /**
+     * Bean class for configurations of a web app.
+     *
+     * @since 0.18.0
+     */
+    public static class AppConfiguration {
+
+        @Element(description = "Context path of this web app.\n" +
+                               "This overrides the default context path (which is '/'+<app-name>) of the app. " +
+                               "Context path should start with a '/' (e.g. '/foo').")
+        private String contextPath;
+
+        @Element(description = "ID of the HTTP listener configuration that this web app should be deployed.\n" +
+                               "'listenerConfigurations' can be found under 'wso2.transport.http' namespace. " +
+                               "If absent, this web app will be deployed to all available HTTPS transports.")
+        private String transportId;
+
+        /**
+         * Returns the context path in this app configuration.
+         *
+         * @return the context path
+         */
+        public Optional<String> getContextPath() {
+            return Optional.ofNullable(contextPath);
+        }
+
+        /**
+         * Returns the transport ID in this app configuration.
+         *
+         * @return the transport ID
+         */
+        public Optional<String> getTransportId() {
+            return Optional.ofNullable(transportId);
+        }
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppDeploymentEventListener.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/AppDeploymentEventListener.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.uis.internal.deployment;
 
 import org.wso2.carbon.uis.api.App;
+import org.wso2.carbon.uis.internal.exception.AppDeploymentEventListenerException;
 
 /**
  * A listener that observes web app deployments.
@@ -31,13 +32,15 @@ public interface AppDeploymentEventListener {
      * Invoked when an app is deployed.
      *
      * @param app the deployed app
+     * @throws AppDeploymentEventListenerException if an error occurred when calling
      */
-    void appDeploymentEvent(App app);
+    void appDeploymentEvent(App app) throws AppDeploymentEventListenerException;
 
     /**
      * Invoked when an app is undeployed.
      *
      * @param appName name of the undeploying app.
+     * @throws AppDeploymentEventListenerException if an error occurred when calling
      */
-    void appUndeploymentEvent(String appName);
+    void appUndeploymentEvent(String appName) throws AppDeploymentEventListenerException;
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/parser/ConfigurationYaml.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/deployment/parser/ConfigurationYaml.java
@@ -29,26 +29,7 @@ import java.util.Map;
  */
 public class ConfigurationYaml {
 
-    private boolean httpsOnly;
     private ResponseHeaders responseHeaders;
-
-    /**
-     * Returns {@code httpsOnly} config value.
-     *
-     * @return {@code httpsOnly} config
-     */
-    public boolean isHttpsOnly() {
-        return httpsOnly;
-    }
-
-    /**
-     * Sets {@code httpsOnly} config value.
-     *
-     * @param httpsOnly config value
-     */
-    public void setHttpsOnly(boolean httpsOnly) {
-        this.httpsOnly = httpsOnly;
-    }
 
     /**
      * Returns {@code responseHeaders} config value.
@@ -74,8 +55,7 @@ public class ConfigurationYaml {
      * @return {@link Configuration} object
      */
     public Configuration toConfiguration() {
-        return new Configuration(this.httpsOnly,
-                                 new Configuration.HttpResponseHeaders(this.responseHeaders.getPages(),
+        return new Configuration(new Configuration.HttpResponseHeaders(this.responseHeaders.getPages(),
                                                                        this.responseHeaders.getResources()));
     }
 

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/AppDeploymentEventListenerException.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/exception/AppDeploymentEventListenerException.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.exception;
+
+import org.wso2.carbon.uis.api.exception.UISRuntimeException;
+
+/**
+ * Indicates an error occurred when invoking an app deployment event listener.
+ *
+ * @see org.wso2.carbon.uis.internal.deployment.AppDeploymentEventListener
+ * @since 0.18.0
+ */
+public class AppDeploymentEventListenerException extends UISRuntimeException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public AppDeploymentEventListenerException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public AppDeploymentEventListenerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public AppDeploymentEventListenerException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public AppDeploymentEventListenerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/HttpTransport.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/HttpTransport.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.uis.internal.http;
 
+import org.wso2.carbon.uis.internal.http.util.IpAddressUtils;
+
 import java.util.Locale;
 import java.util.Objects;
 
@@ -28,7 +30,8 @@ import java.util.Objects;
  */
 public class HttpTransport {
 
-    private final String id;
+    private final String listenerInterfaceId;
+    private final String listenerConfigurationId;
     private final String scheme;
     private final String host;
     private final int port;
@@ -36,25 +39,37 @@ public class HttpTransport {
     /**
      * Creates a new HTTP transport.
      *
-     * @param id     ID of the transport
-     * @param scheme scheme of the transport (either {@code http} or {@code https})
-     * @param host   host name of the transport
-     * @param port   port of the transport
+     * @param listenerInterfaceId     ID of the listener interface
+     * @param listenerConfigurationId ID of the listener configuration
+     * @param scheme                  scheme of the transport (either {@code http} or {@code https})
+     * @param host                    host name of the transport
+     * @param port                    port of the transport
      */
-    public HttpTransport(String id, String scheme, String host, int port) {
-        this.id = id;
+    public HttpTransport(String listenerInterfaceId, String listenerConfigurationId,
+                         String scheme, String host, int port) {
+        this.listenerInterfaceId = listenerInterfaceId;
+        this.listenerConfigurationId = listenerConfigurationId;
         this.scheme = scheme.toLowerCase(Locale.ENGLISH);
         this.host = host;
         this.port = port;
     }
 
     /**
-     * Returns the ID of the represented HTTP transport.
+     * Returns the ID of the listener interface of the represented HTTP transport
      *
-     * @return ID of the HTTP transport
+     * @return ID of the listener interface
      */
-    public String getId() {
-        return id;
+    public String getListenerInterfaceId() {
+        return listenerInterfaceId;
+    }
+
+    /**
+     * Returns the ID of the listener configuration of the represented HTTP transport
+     *
+     * @return ID of the listener configuration
+     */
+    public String getListenerConfigurationId() {
+        return listenerConfigurationId;
     }
 
     /**
@@ -93,18 +108,41 @@ public class HttpTransport {
         return Objects.equals(scheme, "https");
     }
 
+    /**
+     * Returns an accessible URL for the given context path via this HTTP transport.
+     *
+     * @param contextPath content path of the URL
+     * @return URL
+     */
+    public String getUrlFor(String contextPath) {
+        String properHost = host;
+        if ("localhost".equals(host) || "127.0.0.1".equals(host) || "0.0.0.0".equals(host) || "::1".equals(host)) {
+            properHost = IpAddressUtils.getLocalIpAddress().orElse(host);
+        }
+        return scheme + "://" + properHost + ":" + port + contextPath;
+    }
+
     @Override
     public boolean equals(Object obj) {
-        return (this == obj) || ((obj instanceof HttpTransport) && Objects.equals(id, ((HttpTransport) obj).id));
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof HttpTransport)) {
+            return false;
+        }
+        HttpTransport other = (HttpTransport) obj;
+        return Objects.equals(listenerInterfaceId, other.listenerInterfaceId) &&
+               Objects.equals(listenerConfigurationId, other.listenerConfigurationId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(listenerInterfaceId, listenerConfigurationId);
     }
 
     @Override
     public String toString() {
-        return "HttpTransport{id='" + id + "', scheme='" + scheme + "', host='" + host + "', port='" + port + "'}";
+        return "HttpTransport{listenerInterfaceId='" + listenerInterfaceId + "', listenerConfigurationId='" +
+               listenerConfigurationId + "', scheme='" + scheme + "', host='" + host + "', port=" + port + '}';
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/msf4j/MicroserviceRegistration.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/msf4j/MicroserviceRegistration.java
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uis.internal.http.HttpTransport;
 import org.wso2.msf4j.Microservice;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 
 /**
  * Represents a Microservice registration to the HTTP transport(s).
@@ -36,19 +35,28 @@ public class MicroserviceRegistration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MicroserviceRegistration.class);
 
-    private final Map<HttpTransport, ServiceRegistration<Microservice>> microserviceRegistrations;
+    private final HttpTransport httpTransport;
+    private final ServiceRegistration<Microservice> microserviceRegistration;
 
-    MicroserviceRegistration(Map<HttpTransport, ServiceRegistration<Microservice>> microserviceRegistrations) {
-        this.microserviceRegistrations = microserviceRegistrations;
+    /**
+     * Creates a new Microservice service registration.
+     *
+     * @param httpTransport            HTTP transport
+     * @param microserviceRegistration Microservice OSGi service registration
+     */
+    public MicroserviceRegistration(HttpTransport httpTransport,
+                                    ServiceRegistration<Microservice> microserviceRegistration) {
+        this.httpTransport = httpTransport;
+        this.microserviceRegistration = microserviceRegistration;
     }
 
     /**
-     * Returns HTTP transports that this registration occurred.
+     * Returns the HTTP transport that this registration occurred.
      *
-     * @return HTTP transports that the registration occurred
+     * @return relevant HTTP transport
      */
-    public Set<HttpTransport> getRegisteredHttpTransports() {
-        return microserviceRegistrations.keySet();
+    public HttpTransport getRegisteredHttpTransport() {
+        return httpTransport;
     }
 
     /**
@@ -57,9 +65,31 @@ public class MicroserviceRegistration {
      * @throws IllegalStateException if Microservice is already unregistered
      */
     public void unregister() {
-        microserviceRegistrations.forEach((httpTransport, microserviceServiceRegistration) -> {
-            microserviceServiceRegistration.unregister();
-            LOGGER.debug("Microservice unregistered from HTTP transport {}.", httpTransport);
-        });
+        microserviceRegistration.unregister();
+        LOGGER.debug("Microservice unregistered from HTTP transport {}.", httpTransport);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof MicroserviceRegistration)) {
+            return false;
+        }
+        MicroserviceRegistration other = (MicroserviceRegistration) obj;
+        return Objects.equals(httpTransport, other.httpTransport) &&
+               Objects.equals(microserviceRegistration, other.microserviceRegistration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(httpTransport, microserviceRegistration);
+    }
+
+    @Override
+    public String toString() {
+        return "MicroserviceRegistration{httpTransport=" + httpTransport + ", microserviceRegistration=" +
+               microserviceRegistration + "}";
     }
 }

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/util/IpAddressUtils.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/http/util/IpAddressUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uis.internal.http.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.Optional;
+
+/**
+ * Utility functions for Internet Protocol  addresses.
+ *
+ * @since 0.18.0
+ */
+public class IpAddressUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IpAddressUtils.class);
+    private static String localInternetAddress;
+
+    /**
+     * Returns Internet Protocol version 4 (IPv4) address of this computer.
+     *
+     * @return IP address of this computer
+     */
+    public static Optional<String> getLocalIpAddress() {
+        if (localInternetAddress != null) {
+            return Optional.of(localInternetAddress);
+        }
+
+        try {
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            outer_loop:
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = networkInterfaces.nextElement();
+                if (!networkInterface.isUp() || networkInterface.isLoopback() || networkInterface.isVirtual()) {
+                    continue;
+                }
+
+                Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
+                while (inetAddresses.hasMoreElements()) {
+                    InetAddress inetAddress = inetAddresses.nextElement();
+                    if ((inetAddress instanceof Inet4Address) && !inetAddress.isLoopbackAddress()) {
+                        localInternetAddress = inetAddress.getHostAddress();
+                        break outer_loop;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            // Log level DEBUG since this is not a 'breaking' error.
+            LOGGER.debug("Cannot access information on network interfaces.", e);
+        }
+        return Optional.ofNullable(localInternetAddress);
+    }
+}

--- a/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/deployment/ArtifactAppDeployer.java
+++ b/components/org.wso2.carbon.uis/src/main/java/org/wso2/carbon/uis/internal/io/deployment/ArtifactAppDeployer.java
@@ -169,20 +169,13 @@ public class ArtifactAppDeployer implements Deployer {
 
     private String getAppContextPath(AppReference appReference) throws CarbonDeploymentException {
         String appName = appReference.getName();
-        String contextPath = serverConfiguration.getContextPaths().get(appName);
-        if (contextPath == null) {
-            return ("/" + appName); // default context path
-        } else {
-            if (contextPath.isEmpty()) {
-                throw new CarbonDeploymentException(
-                        "Cannot deploy web app '" + appName + "' as the configured context path is empty.");
-            } else if (contextPath.charAt(0) != '/') {
-                throw new CarbonDeploymentException(
-                        "Cannot deploy web app '" + appName + "' as the configured context path '" + contextPath +
-                        "' does not start with a '/'.");
-            } else {
-                return contextPath;
-            }
+        try {
+            return serverConfiguration.getConfigurationForApp(appName)
+                    .flatMap(ServerConfiguration.AppConfiguration::getContextPath)
+                    .orElse("/" + appName); // default context path
+        } catch (IllegalArgumentException e) {
+            throw new CarbonDeploymentException(
+                    "Cannot deploy web app '" + appName + "' as the configured app context path is invalid.", e);
         }
     }
 

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ConfigurationTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ConfigurationTest.java
@@ -37,17 +37,10 @@ import static java.util.Collections.singletonMap;
 public class ConfigurationTest {
 
     @Test
-    public void testIsHttpsOnly() {
-        Configuration configuration = new Configuration(false, null);
-        Assert.assertEquals(configuration.isHttpsOnly(), false);
-    }
-
-    @Test
     public void testGetResponseHeaders() {
         Map<String, String> pages = singletonMap(HEADER_EXPIRES, "100");
         Map<String, String> staticResources = singletonMap(HEADER_CACHE_CONTROL, "public,max-age=100");
-        Configuration configuration = new Configuration(true,
-                                                        new Configuration.HttpResponseHeaders(pages, staticResources));
+        Configuration configuration = new Configuration(new Configuration.HttpResponseHeaders(pages, staticResources));
 
         Assert.assertEquals(configuration.getResponseHeaders().forPages().get(HEADER_PRAGMA),
                             Configuration.DEFAULT_CONFIGURATION.getResponseHeaders().forPages().get(HEADER_PRAGMA));

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ServerConfigurationTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/api/ServerConfigurationTest.java
@@ -31,6 +31,6 @@ public class ServerConfigurationTest {
     @Test
     public void testGetContextPaths() {
         ServerConfiguration serverConfiguration = new ServerConfiguration();
-        Assert.assertTrue(serverConfiguration.getContextPaths().isEmpty());
+        Assert.assertFalse(serverConfiguration.getConfigurationForApp("foo").isPresent());
     }
 }

--- a/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/msf4j/MicroserviceRegistrationTest.java
+++ b/components/org.wso2.carbon.uis/src/test/java/org/wso2/carbon/uis/internal/http/msf4j/MicroserviceRegistrationTest.java
@@ -18,14 +18,10 @@
 
 package org.wso2.carbon.uis.internal.http.msf4j;
 
-import com.google.common.collect.ImmutableMap;
 import org.osgi.framework.ServiceRegistration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uis.internal.http.HttpTransport;
-import org.wso2.msf4j.Microservice;
-
-import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,26 +35,26 @@ public class MicroserviceRegistrationTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testGetRegisteredHttpTransports() {
-        Map<HttpTransport, ServiceRegistration<Microservice>> serviceRegistrations =
-                ImmutableMap.of(createHttpTransport("foo"), mock(ServiceRegistration.class));
-        MicroserviceRegistration microserviceRegistration = new MicroserviceRegistration(serviceRegistrations);
+    public void testGetRegisteredHttpTransport() {
+        HttpTransport httpTransport = createHttpTransport();
+        ServiceRegistration serviceRegistration = mock(ServiceRegistration.class);
+        MicroserviceRegistration microserviceRegistration = new MicroserviceRegistration(httpTransport,
+                                                                                         serviceRegistration);
 
-        Assert.assertEquals(microserviceRegistration.getRegisteredHttpTransports(), serviceRegistrations.keySet());
+        Assert.assertEquals(microserviceRegistration.getRegisteredHttpTransport(), httpTransport);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testUnregister() {
-        Map<HttpTransport, ServiceRegistration<Microservice>> serviceRegistrations =
-                ImmutableMap.of(createHttpTransport("foo"), mock(ServiceRegistration.class),
-                                createHttpTransport("bar"), mock(ServiceRegistration.class));
-        new MicroserviceRegistration(serviceRegistrations).unregister();
+        HttpTransport httpTransport = createHttpTransport();
+        ServiceRegistration serviceRegistration = mock(ServiceRegistration.class);
+        new MicroserviceRegistration(httpTransport, serviceRegistration).unregister();
 
-        serviceRegistrations.values().forEach(serviceRegistration -> verify(serviceRegistration).unregister());
+        verify(serviceRegistration).unregister();
     }
 
-    private static HttpTransport createHttpTransport(String id) {
-        return new HttpTransport(id, "http", "localhost", 9292);
+    private static HttpTransport createHttpTransport() {
+        return new HttpTransport("foo", "bar", "http", "localhost", 9292);
     }
 }

--- a/components/org.wso2.carbon.uis/src/test/resources/apps/full-app/configuration.yaml
+++ b/components/org.wso2.carbon.uis/src/test/resources/apps/full-app/configuration.yaml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-httpsOnly: true
-
 responseHeaders:
   resources:
     "Content-Security-Policy": "default-src 'none'; script-src 'self' ssl.google-analytics.com;"

--- a/features/org.wso2.carbon.uis.feature/pom.xml
+++ b/features/org.wso2.carbon.uis.feature/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.17.3-SNAPSHOT</version>
+        <version>0.18.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.wso2.carbon.uis</groupId>
     <artifactId>uis-parent</artifactId>
-    <version>0.17.3-SNAPSHOT</version>
+    <version>0.18.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WSO2 Carbon UI Server - Parent</name>
@@ -358,7 +358,7 @@
     </build>
 
     <properties>
-        <carbon.uis.version>0.17.3-SNAPSHOT</carbon.uis.version>
+        <carbon.uis.version>0.18.0-SNAPSHOT</carbon.uis.version>
 
         <!--Kernel-->
         <carbon.kernel.version>5.2.5</carbon.kernel.version>

--- a/tests/distribution/carbon-home/conf/default/deployment.yaml
+++ b/tests/distribution/carbon-home/conf/default/deployment.yaml
@@ -49,7 +49,7 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9090
 
-    - id: "default-https"
+    - id: "for-test-app"
       host: "0.0.0.0"
       port: 9443
       scheme: https
@@ -61,5 +61,7 @@ wso2.transport.http:
     - id: "default-http-sender"
 
 wso2.carbon-ui-server:
-  contextPaths:
-    "test": "/sample"
+  apps:
+    "test":
+      contextPath: "/sample"
+      transportId: "for-test-app"

--- a/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
+++ b/tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml
@@ -1,5 +1,20 @@
-# Set this to true if you want to deploy this web app *only* in HTTPS.
-httpsOnly: true
+#
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
 # HTTP response headers.
 responseHeaders:

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis.tests</groupId>
         <artifactId>tests-parent</artifactId>
-        <version>0.17.3-SNAPSHOT</version>
+        <version>0.18.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.wso2.carbon.uis</groupId>
         <artifactId>uis-parent</artifactId>
-        <version>0.17.3-SNAPSHOT</version>
+        <version>0.18.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
Currently there is no option to deploy a web app to a specific HTTP transport.

## Goals
$subject

## Approach
- Change the `ServerConfiguration` class to accept following new configurations from `deployment.yaml`
```yaml
wso2.carbon-ui-server:
  apps:
    <app_name>:
      contextPath: <app_context_path>
      transportId: <transport_id>
    <another_app_name>:
      # if you don't want to override context path, then do not put one here
      transportId: <another_transport_id>

wso2.transport.http:
  listenerConfigurations:
    - id: <transport_id>
      host: "0.0.0.0"
      port: 9090

    - id:<another_transport_id>
      host: "0.0.0.0"
      port: 9443
      scheme: https
      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
      keyStorePassword: wso2carbon
      certPass: wso2carbon

  senderConfigurations:
    - id: "default-http-sender"
```
- Remove redundant `httpsOnly: true` configuration from `configuration.yaml` of in web apps.
- Bump repo version to v0.18.0-SNAPSHOT

## Documentation
- `deploymet.yaml`
```yaml

# Carbon UI server configurations
wso2.carbon-ui-server:
  apps:
    # configurations for the Portal app
    "portal":
      contextPath: "/dashboard"
      transportId: "for-portal-app"

# HTTP transport related configurations
wso2.transport.http:
  transportProperties:
    - name: "server.bootstrap.socket.timeout"
      value: 60
    - name: "client.bootstrap.socket.timeout"
      value: 60
    - name: "latency.metrics.enabled"
      value: true

  listenerConfigurations:
    - id: "default-http"
      host: "0.0.0.0"
      port: 9090

   # HTTP transport for the Portal web app
    - id: "for-portal-app"
      host: "0.0.0.0"
      port: 9443
      scheme: https
      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
      keyStorePassword: wso2carbon
      certPass: wso2carbon

  senderConfigurations:
    - id: "default-http-sender"

```
- `configuration.yaml`
```yaml
# HTTP response headers.
responseHeaders:
  # HTTP response headers for static resources.
  resources:
    "Content-Security-Policy": "default-src 'none'; script-src 'self' ssl.google-analytics.com;"
  # HTTP response headers for pages.
  pages:
    "X-Frame-Options": "DENY"
```

## Automation tests
 - Unit tests 
   Code coverage: 66%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
- [tests/distribution/carbon-home/conf/default/deployment.yaml](https://github.com/this/carbon-ui-server/blob/f78ad99f68bd393565235ab551e343dead860438/tests/distribution/carbon-home/conf/default/deployment.yaml)
- [tests/distribution/carbon-home/wso2/default/deployment/web-ui-apps/test/configuration.yaml](https://github.com/wso2/carbon-ui-server/pull/64/files#diff-5b2a954a78f92d4fc8e6d7112c1f6723)

## Related PRs
> List any other related PRs

## Migrations (if applicable)
- From v0.17.1 below
  - remove `httpsOnly: true` line from `configuration.yaml` of web apps
