### PR TITLE
Bump MSF4J version to v2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,12 +376,12 @@
         <carbon.utils.version>2.0.2</carbon.utils.version>
 
         <!--MSF4J-->
-        <msf4j.version>2.5.0</msf4j.version>
-        <msf4j.version.range>[2.5.0, 3.0.0)</msf4j.version.range>
+        <msf4j.version>2.5.1</msf4j.version>
+        <msf4j.version.range>[2.5.1, 3.0.0)</msf4j.version.range>
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>
         <!--Transport-->
-        <transport.http.netty.version>6.0.63</transport.http.netty.version>
-        <transport.http.netty.version.range>[6.0.63, 7.0.0)</transport.http.netty.version.range>
+        <transport.http.netty.version>6.0.64</transport.http.netty.version>
+        <transport.http.netty.version.range>[6.0.64, 7.0.0)</transport.http.netty.version.range>
         <!--Metrics-->
         <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <carbon.jndi.version>1.0.4</carbon.jndi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -366,8 +366,8 @@
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
 
         <!--Deployment-->
-        <carbon.deployment.version>5.1.5</carbon.deployment.version>
-        <carbon.deployment.version.range>[5.0.0, 6.0.0)</carbon.deployment.version.range>
+        <carbon.deployment.version>5.1.9</carbon.deployment.version>
+        <carbon.deployment.version.range>[5.1.9, 6.0.0)</carbon.deployment.version.range>
 
         <!--Config-->
         <carbon.config.version>2.1.5</carbon.config.version>


### PR DESCRIPTION
## Purpose
- Bump MSF4J version to v2.5.1
- Bump transport.http version to v6.0.64
- Bump carbon.deployment version to v5.1.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
