### PR TITLE
Rename UISException, UISRuntimeException classes

### DIFF
--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/HttpErrorException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/HttpErrorException.java
@@ -23,7 +23,7 @@ package org.wso2.carbon.uiserver.api.exception;
  *
  * @since 0.8.0
  */
-public class HttpErrorException extends UISRuntimeException {
+public class HttpErrorException extends UiServerRuntimeException {
 
     private final int httpStatusCode;
 

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/RenderingException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/RenderingException.java
@@ -23,7 +23,7 @@ package org.wso2.carbon.uiserver.api.exception;
  *
  * @since 0.8.0
  */
-public class RenderingException extends UISRuntimeException {
+public class RenderingException extends UiServerRuntimeException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/UiServerException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/UiServerException.java
@@ -23,13 +23,13 @@ package org.wso2.carbon.uiserver.api.exception;
  *
  * @since 0.8.0
  */
-public class UISException extends Exception {
+public class UiServerException extends Exception {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
      * subsequently be initialized by a call to {@link #initCause(Throwable)}.
      */
-    public UISException() {
+    public UiServerException() {
     }
 
     /**
@@ -38,7 +38,7 @@ public class UISException extends Exception {
      *
      * @param message the detail message of the exception
      */
-    public UISException(String message) {
+    public UiServerException(String message) {
         super(message);
     }
 
@@ -48,7 +48,7 @@ public class UISException extends Exception {
      *
      * @param cause the cause of the exception
      */
-    public UISException(Throwable cause) {
+    public UiServerException(Throwable cause) {
         super(cause);
     }
 
@@ -58,7 +58,7 @@ public class UISException extends Exception {
      * @param message the detail message of the exception
      * @param cause   the cause of the exception
      */
-    public UISException(String message, Throwable cause) {
+    public UiServerException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/UiServerRuntimeException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/api/exception/UiServerRuntimeException.java
@@ -23,13 +23,13 @@ package org.wso2.carbon.uiserver.api.exception;
  *
  * @since 0.8.0
  */
-public class UISRuntimeException extends RuntimeException {
+public class UiServerRuntimeException extends RuntimeException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
      * subsequently be initialized by a call to {@link #initCause(Throwable)}.
      */
-    public UISRuntimeException() {
+    public UiServerRuntimeException() {
     }
 
     /**
@@ -38,7 +38,7 @@ public class UISRuntimeException extends RuntimeException {
      *
      * @param message the detail message of the exception
      */
-    public UISRuntimeException(String message) {
+    public UiServerRuntimeException(String message) {
         super(message);
     }
 
@@ -48,7 +48,7 @@ public class UISRuntimeException extends RuntimeException {
      *
      * @param cause the cause of the exception
      */
-    public UISRuntimeException(Throwable cause) {
+    public UiServerRuntimeException(Throwable cause) {
         super(cause);
     }
 
@@ -58,7 +58,7 @@ public class UISRuntimeException extends RuntimeException {
      * @param message the detail message of the exception
      * @param cause   the cause of the exception
      */
-    public UISRuntimeException(String message, Throwable cause) {
+    public UiServerRuntimeException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/AppCreationException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/AppCreationException.java
@@ -18,14 +18,14 @@
 
 package org.wso2.carbon.uiserver.internal.exception;
 
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 
 /**
  * Indicates an error occurred when creating a web app.
  *
  * @since 0.8.0
  */
-public class AppCreationException extends UISRuntimeException {
+public class AppCreationException extends UiServerRuntimeException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/AppDeploymentEventListenerException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/AppDeploymentEventListenerException.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.uiserver.internal.exception;
 
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 
 /**
  * Indicates an error occurred when invoking an app deployment event listener.
@@ -26,7 +26,7 @@ import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
  * @see org.wso2.carbon.uiserver.internal.deployment.AppDeploymentEventListener
  * @since 0.18.0
  */
-public class AppDeploymentEventListenerException extends UISRuntimeException {
+public class AppDeploymentEventListenerException extends UiServerRuntimeException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/FileOperationException.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/exception/FileOperationException.java
@@ -19,14 +19,14 @@
 package org.wso2.carbon.uiserver.internal.exception;
 
 
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 
 /**
  * Indicates an error occurred in a file system related operation.
  *
  * @since 0.8.0
  */
-public class FileOperationException extends UISRuntimeException {
+public class FileOperationException extends UiServerRuntimeException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/http/RequestDispatcher.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/http/RequestDispatcher.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.uiserver.internal.http;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uiserver.api.App;
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 import org.wso2.carbon.uiserver.api.http.HttpRequest;
 import org.wso2.carbon.uiserver.api.http.HttpResponse;
 import org.wso2.carbon.uiserver.internal.io.http.StaticRequestDispatcher;
@@ -71,7 +71,7 @@ public class RequestDispatcher {
             } else {
                 return pageRequestDispatcher.serve(request);
             }
-        } catch (UISRuntimeException e) {
+        } catch (UiServerRuntimeException e) {
             LOGGER.error("An error occurred when serving for request '{}'.", request, e);
             return ResponseBuilder.serverError("A server occurred while serving for request.").build();
         } catch (Exception e) {

--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/io/util/MimeMapper.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/io/util/MimeMapper.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.uiserver.internal.io.util;
 
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -40,17 +40,17 @@ public class MimeMapper {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, String> loadMimeTypes() throws UISRuntimeException {
+    private static Map<String, String> loadMimeTypes() throws UiServerRuntimeException {
         try (InputStream inputStream = MimeMapper.class.getClassLoader().getResourceAsStream(FILE_NAME_MIME_TYPES)) {
             if (inputStream == null) {
-                throw new UISRuntimeException(
+                throw new UiServerRuntimeException(
                         "Cannot find MIME types file '" + FILE_NAME_MIME_TYPES + "' in class path.");
             }
             return new Yaml().loadAs(inputStream, Map.class);
         } catch (IOException e) {
-            throw new UISRuntimeException("Cannot read MIME types file '" + FILE_NAME_MIME_TYPES + "'.", e);
+            throw new UiServerRuntimeException("Cannot read MIME types file '" + FILE_NAME_MIME_TYPES + "'.", e);
         } catch (Exception e) {
-            throw new UISRuntimeException("MIME types file is '" + FILE_NAME_MIME_TYPES + "' is invalid.", e);
+            throw new UiServerRuntimeException("MIME types file is '" + FILE_NAME_MIME_TYPES + "' is invalid.", e);
         }
     }
 
@@ -59,9 +59,9 @@ public class MimeMapper {
      *
      * @param extension file extension
      * @return MIME type for the given file extension
-     * @throws UISRuntimeException if cannot find or read the MIME types file, or it is invalid
+     * @throws UiServerRuntimeException if cannot find or read the MIME types file, or it is invalid
      */
-    public static Optional<String> getMimeType(String extension) throws UISRuntimeException {
+    public static Optional<String> getMimeType(String extension) throws UiServerRuntimeException {
         if (mimeTypes == null) {
             synchronized (MimeMapper.class) {
                 if (mimeTypes == null) {

--- a/components/org.wso2.carbon.uiserver/src/test/java/org/wso2/carbon/uiserver/internal/http/RequestDispatcherTest.java
+++ b/components/org.wso2.carbon.uiserver/src/test/java/org/wso2/carbon/uiserver/internal/http/RequestDispatcherTest.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.uiserver.internal.http;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.wso2.carbon.uiserver.api.exception.UISRuntimeException;
+import org.wso2.carbon.uiserver.api.exception.UiServerRuntimeException;
 import org.wso2.carbon.uiserver.api.http.HttpRequest;
 import org.wso2.carbon.uiserver.api.http.HttpResponse;
 import org.wso2.carbon.uiserver.internal.io.http.StaticRequestDispatcher;
@@ -83,7 +83,7 @@ public class RequestDispatcherTest {
     public void testServeWhenUISRuntimeException() {
         HttpRequest request = createPageRequest();
         PageRequestDispatcher pageRequestDispatcher = mock(PageRequestDispatcher.class);
-        when(pageRequestDispatcher.serve(any())).thenThrow(UISRuntimeException.class);
+        when(pageRequestDispatcher.serve(any())).thenThrow(UiServerRuntimeException.class);
 
         HttpResponse response = new RequestDispatcher(pageRequestDispatcher, null).serve(request);
         Assert.assertEquals(response.getStatus(), HttpResponse.STATUS_INTERNAL_SERVER_ERROR);

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -405,7 +405,6 @@
                                 <delete dir="target/dependency-maven-plugin-markers" />
                                 <delete dir="target/org.eclipse.equinox.executable-3.5.0.v20110530-7P7NFUFFLWUl76mart" />
                                 <delete dir="target/p2-repo" />
-                                <!-- TODO: Figure out a way to delete tmp.* files -->
                                 <delete file="target/tmp" />
                                 <delete dir="target/wso2carbon-kernel-${carbon.kernel.version}" />
                                 <delete dir="target/antrun" />


### PR DESCRIPTION
## Purpose
Rename UISException class to UiServerException and UISRuntimeException class to UiServerRuntimeException, as [suggested in code review](https://groups.google.com/a/wso2.com/d/msg/engineering-group/aMA_U4QCjN4/s5uBWGGUCQAJ).

## Approach
- Renames following classes
  - UISException --> **UiServerException**
  - UISRuntimeException --> **UiServerRuntimeException**

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
