### PR TITLE
Allow multiple 'RestApiProvider's for the same webapp

### DIFF
--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/deployment/listener/AppTransportBinder.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/deployment/listener/AppTransportBinder.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentMap;
  * Binder that registers web apps to the HTTP transport layer.
  * <p>
  * This class is responsible for binding a web app to the HTTP transport layer, when that web app gets deployed. When
- * the web app gets updeloyed, it will be unbound from the transport layer.
+ * the web app gets undeployed, it will be unbound from the transport layer.
  *
  * @since 0.15.0
  */

--- a/pom.xml
+++ b/pom.xml
@@ -405,8 +405,8 @@
         <!--Other-->
         <netty.version>4.0.30.Final</netty.version>
         <netty.version.range>[4.0.30, 5.0.0)</netty.version.range>
-        <guava.version>23.0</guava.version>
-        <guava.version.range>[23.0, 24.0)</guava.version.range>
+        <guava.version>21.0</guava.version>
+        <guava.version.range>[21.0, 22.0)</guava.version.range>
         <gson.version>2.7</gson.version>
         <gson.version.range>[2.6, 3.0)</gson.version.range>
         <snakeyaml.version>1.19</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -405,8 +405,8 @@
         <!--Other-->
         <netty.version>4.0.30.Final</netty.version>
         <netty.version.range>[4.0.30, 5.0.0)</netty.version.range>
-        <guava.version>20.0</guava.version>
-        <guava.version.range>[20.0,21.0)</guava.version.range>
+        <guava.version>23.0</guava.version>
+        <guava.version.range>[23.0, 24.0)</guava.version.range>
         <gson.version>2.7</gson.version>
         <gson.version.range>[2.6, 3.0)</gson.version.range>
         <snakeyaml.version>1.19</snakeyaml.version>


### PR DESCRIPTION
## Purpose
This PR adds the capability to have multiple `RestApiProvider`s for the same webapp.

## Automation tests
 - Unit tests 
   Code coverage: 66%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
