### PR TITLE
Migrating to MSF4J v2.6.0

### DIFF
--- a/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/deployment/msf4j/MicroservicesRegistrar.java
+++ b/components/org.wso2.carbon.uiserver/src/main/java/org/wso2/carbon/uiserver/internal/deployment/msf4j/MicroservicesRegistrar.java
@@ -96,7 +96,7 @@ public class MicroservicesRegistrar {
             propertyKeyContextPath = msf4jConstants.getDeclaredField("CONTEXT_PATH").get(null).toString();
         } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
             // If reflection fails, use hard-coded ones.
-            propertyKeyListenerInterfaceId = "LISTENER_INTERFACE_ID";
+            propertyKeyListenerInterfaceId = "listener.interface.id";
             propertyKeyContextPath = "contextPath";
             LOGGER.debug("Cannot access constants in MSF4JConstants class via reflection.", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -376,8 +376,8 @@
         <carbon.utils.version>2.0.2</carbon.utils.version>
 
         <!--MSF4J-->
-        <msf4j.version>2.5.2</msf4j.version>
-        <msf4j.version.range>[2.5.2, 3.0.0)</msf4j.version.range>
+        <msf4j.version>2.6.0</msf4j.version>
+        <msf4j.version.range>[2.6.0, 3.0.0)</msf4j.version.range>
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>
         <!--Transport-->
         <transport.http.netty.version>6.0.64</transport.http.netty.version>


### PR DESCRIPTION
## Purpose
$subject.

## Goals
- Making usage values of constants defined in [`org.wso2.msf4j.internal.MSF4JConstants`](https://github.com/wso2/msf4j/blob/v2.6.0/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java) class "migration-safe" as those constants has been changed between MSF4J v2.5.2 and v2.6.0 versions.

## Approach
- Access values of [`CHANNEL_ID`](https://github.com/wso2/msf4j/blob/v2.6.0/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java#L24), [`CONTEXT_PATH`](https://github.com/wso2/msf4j/blob/v2.6.0/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java#L25) constants in the `MSF4JConstants` class via reflection.
- If reflection fails use hard-coded values.

## Automation tests
 - Unit tests 
   - passes all current tests
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
