### PR TITLE
Bump 3rd party dependency versions

### DIFF
--- a/features/org.wso2.carbon.uiserver.feature/pom.xml
+++ b/features/org.wso2.carbon.uiserver.feature/pom.xml
@@ -88,7 +88,11 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>com.google.guava</symbolicName>
-                                    <version>${guava.version}.0</version>
+                                    <version>${guava.bundle.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>com.google.guava.failureaccess</symbolicName>
+                                    <version>${guava.failureaccess.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>handlebars</symbolicName>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>failureaccess</artifactId>
+                <version>${guava.failureaccess.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
@@ -426,20 +431,23 @@
         <!--Other-->
         <netty.version>4.1.34.Final</netty.version>
         <netty.version.range>[4.0.30, 5.0.0)</netty.version.range>
-        <guava.version>23.0</guava.version>
-        <guava.version.range>[21.0, 24.0)</guava.version.range>
-        <gson.version>2.8.5</gson.version>
+        <guava.version>31.1-jre</guava.version>
+        <guava.bundle.version>31.1.0.jre</guava.bundle.version>
+        <guava.version.range>[21.0, 32.0)</guava.version.range>
+        <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
+        <gson.version>2.9.1</gson.version>
         <gson.version.range>[2.6, 3.0)</gson.version.range>
-        <snakeyaml.version>1.19</snakeyaml.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
         <snakeyaml.version.range>[1.19.0, 2.0.0)</snakeyaml.version.range>
         <org.apache.commons.commons-lang3.version>3.3.2</org.apache.commons.commons-lang3.version>
         <org.apache.commons.commons-lang3.version.range>[3.1, 4.0)</org.apache.commons.commons-lang3.version.range>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
         <commons-io.wso2.version.range>[2.4.0, 3.0.0)</commons-io.wso2.version.range>
         <!-- Handlebars -->
-        <orbit.com.github.jknack.handlebars.version>4.0.7.wso2v1</orbit.com.github.jknack.handlebars.version>
+        <orbit.com.github.jknack.handlebars.version>4.3.1.wso2v1</orbit.com.github.jknack.handlebars.version>
+
         <orbit.com.github.jknack.handlebars.version.range>[4.0.7, 5.0.0)</orbit.com.github.jknack.handlebars.version.range>
-        <antlr-version>4.7.2</antlr-version>
+        <antlr-version>4.11.1</antlr-version>
 
         <!--Test-->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
## Purpose
Following Dependencies have been updated via this PR guava - 31.1-jre
  - gson - 2.9.1
  - snakeyaml - 1.33
  - handlebars - 4.3.1.wso2v1
  - antlr - 4.11.1

Issue
https://github.com/wso2/api-manager/issues/1395